### PR TITLE
Fix error handling

### DIFF
--- a/gulp/tasks/browserify.js
+++ b/gulp/tasks/browserify.js
@@ -1,8 +1,8 @@
 var browserify = require('browserify');
 var gulp = require('gulp');
 var livereload = require('gulp-livereload');
-var notify = require("gulp-notify");
 var source = require('vinyl-source-stream');
+var handleErrors = require('../util/handleErrors');
 
 module.exports = function() {
 	return browserify({
@@ -11,10 +11,7 @@ module.exports = function() {
 		})
 		.require('backbone/node_modules/underscore', { expose: 'underscore' })
 		.bundle({debug: true})
-		.on('error', notify.onError({
-			message: "<%= error.message %>",
-			title: "JavaScript Error"
-		}))
+		.on('error', handleErrors)
 		.pipe(source('app.js'))
 		.pipe(gulp.dest('./build/'))
 		.pipe(livereload());

--- a/gulp/tasks/compass.js
+++ b/gulp/tasks/compass.js
@@ -1,7 +1,8 @@
-var compass    = require('gulp-compass');
-var gulp       = require('gulp');
-var livereload = require('gulp-livereload');
-var notify     = require('gulp-notify');
+var compass      = require('gulp-compass');
+var gulp         = require('gulp');
+var livereload   = require('gulp-livereload');
+var notify       = require('gulp-notify');
+var handleErrors = require('../util/handleErrors');
 
 module.exports = function() {
 	return gulp.src('./src/sass/*.sass')
@@ -10,9 +11,6 @@ module.exports = function() {
 			css: 'build',
 			sass: 'src/sass'
 		}))
-		.on('error', notify.onError({
-			message: "<%= error.message %>",
-			title: "SASS Error"
-		}))
+		.on('error', handleErrors)
 		.pipe(livereload());
 };

--- a/gulp/util/handleErrors.js
+++ b/gulp/util/handleErrors.js
@@ -1,0 +1,12 @@
+var notify = require("gulp-notify");
+
+module.exports = function() {
+	// Send error to notification center with gulp-notify
+	notify.onError({
+		title: "Compile Error",
+		message: "<%= error.message %>"
+	}).apply(this, arguments);
+
+	// Keep gulp from hanging on this task
+	this.emit('end');
+};

--- a/src/sass/app.sass
+++ b/src/sass/app.sass
@@ -1,4 +1,4 @@
 body
 	-webkit-font-smoothing: antialiased
 	color: #555
-	font-family: sans-serif
+	font-family: sans-serif;


### PR DESCRIPTION
Compile errors would properly report, but cause the gulp task to
hang. This commit abstracts out a resusable error handler that sends
errors to notification center, AND emits an 'end' event, so that gulp
moves on from the task.
