### PR TITLE
Use 'path' module to resolve server root

### DIFF
--- a/gulp/config.js
+++ b/gulp/config.js
@@ -1,3 +1,6 @@
+var path = require('path');
+
 module.exports = {
-  port: '8080'
-}
+	port: '8080',
+	root: path.resolve('./')
+};

--- a/gulp/tasks/serve.js
+++ b/gulp/tasks/serve.js
@@ -4,10 +4,9 @@ var http    = require('http');
 var config  = require('../config');
 
 module.exports = function(){
-	var buildPath = __dirname.split('/gulp/tasks')[0];
 	var app = connect()
 		.use(connect.logger('dev'))
-		.use(connect.static(buildPath));
+		.use(connect.static(config.root));
 
 	http.createServer(app).listen(config.port);
 };


### PR DESCRIPTION
- This should take care of path issues on Windows (#6, #3)
- Moves server root configuration to config.js
