### PR TITLE
Tests with mocha + chai

### DIFF
--- a/gulp/tasks/test.js
+++ b/gulp/tasks/test.js
@@ -1,0 +1,29 @@
+var gulp = require('gulp');
+var mocha = require('gulp-mocha');
+var fs = require('fs');
+require('coffee-script/register');
+
+gulp.task('test', function () {
+
+  var mocha_opts = {};
+
+  try {
+    var opts = fs.readFileSync('test/mocha.opts', 'utf8')
+      .trim()
+      .split(/\s+/);
+
+    opts.forEach(function(val, indx, arry) {
+      if (/^-.+?/.test(val)) {
+        val = val.replace(/^-+(.+?)/, "$1");
+        mocha_opts[val] = arry[indx + 1];
+      }
+    });
+
+  } catch (err) {
+    // ignore
+    console.log("error getting mocha options", err);
+  }
+
+  return gulp.src(['test/**/*.js', 'test/**/*.coffee'])
+    .pipe(mocha(mocha_opts));
+});

--- a/package.json
+++ b/package.json
@@ -28,16 +28,20 @@
   "devDependencies": {
     "browserify-shim": "~3.4.1",
     "browserify": "~3.36.0",
+    "chai": "~1.9.1",
+    "coffee-script": "~1.7.1",
     "coffeeify": "~0.6.0",
     "connect": "~2.14.3",
     "gulp-changed": "~0.3.0",
     "gulp-compass": "~1.1.8",
     "gulp-imagemin": "~0.1.5",
     "gulp-livereload": "~1.2.0",
+    "gulp-mocha": "~0.4.1",
     "gulp-notify": "~1.2.4",
     "gulp-open": "~0.2.8",
     "gulp": "~3.6.0",
     "hbsfy": "~1.3.2",
+    "mocha": "~1.19.0",
     "vinyl-source-stream": "~0.1.1"
   },
   "dependencies": {

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,3 @@
+--ui bdd
+--reporter spec
+--compilers coffee:coffee-script/register

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -1,0 +1,6 @@
+chai = require "chai"
+assert = chai.assert
+
+describe "coffee-test", ->
+  it "tests stuff, in coffee", ->
+    assert true, "truth is true, right?"

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,12 @@
+var chai = require("chai");
+var assert = chai.assert;
+
+describe("js-test", function(){
+
+  it("tests stuff in plain ol'javascript", function(){
+
+    assert(true, "truth is true, right?");
+
+  });
+
+});


### PR DESCRIPTION
Hey Dan!

I though the only missing part of your awesome seed was tests. Here they come!
I choose to use `mocha` + `chai` for awesomeness.

This integration handle both js and coffee written tests. You can test `js` code with `coffee` tests and vice-versa.

Test can be run from:
- mocha cli
- gulp test
- file save (both test and code will trigger)
