### PR TITLE
Use watchify

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Starter Gulp + Browserify project with examples of how to accomplish some common
 Includes the following tools, tasks, and workflows:
 
 - Browserify (with browserify-shim)
+- Watchify (caching version of browserify for super fast rebuilds)
 - Compass
 - CoffeeScript (with source mapping!)
 - jQuery (from npm)

--- a/gulp/config.js
+++ b/gulp/config.js
@@ -2,5 +2,6 @@ var path = require('path');
 
 module.exports = {
 	port: '8080',
-	root: path.resolve('./')
+	root: path.resolve('./'),
+	isWatching: false
 };

--- a/gulp/tasks/browserify.js
+++ b/gulp/tasks/browserify.js
@@ -1,15 +1,53 @@
+/* browserify task
+   ---------------
+   Bundle javascripty things with browserify!
+
+   If the watch task is running, this uses watchify instead
+   of browserify for faster bundling using caching.
+*/
+
 var browserify   = require('browserify');
+var watchify     = require('watchify');
+var bundleLogger = require('../util/bundleLogger');
+var config       = require('../config');
 var gulp         = require('gulp');
 var handleErrors = require('../util/handleErrors');
 var source       = require('vinyl-source-stream');
 
-gulp.task('browserify', function(){
-	return browserify({
-			entries: ['./src/javascript/app.coffee'],
-			extensions: ['.coffee', '.hbs']
-		})
-		.bundle({debug: true})
-		.on('error', handleErrors)
-		.pipe(source('app.js'))
-		.pipe(gulp.dest('./build/'));
+gulp.task('browserify', function() {
+
+	var bundleMethod = config.isWatching ? watchify : browserify;
+
+	var bundler = bundleMethod({
+		// Specify the entry point of your app
+		entries: ['./src/javascript/app.coffee'],
+		// Add file extentions to make optional in your requires
+		extensions: ['.coffee', '.hbs']
+	});
+
+	var bundle = function() {
+		// Log when bundling starts
+		bundleLogger.start();
+
+		return bundler
+			// Enable source maps!
+			.bundle({debug: true})
+			// Report compile errors
+			.on('error', handleErrors)
+			// Use vinyl-source-stream to make the
+			// stream gulp compatible. Specifiy the
+			// desired output filename here.
+			.pipe(source('app.js'))
+			// Specify the output destination
+			.pipe(gulp.dest('./build/'))
+			// Log when bundling completes!
+			.on('end', bundleLogger.end);
+	};
+
+	if(config.isWatching) {
+		// Rebundle with watchify on changes.
+		bundler.on('update', bundle);
+	}
+
+	return bundle();
 });

--- a/gulp/tasks/default.js
+++ b/gulp/tasks/default.js
@@ -1,3 +1,3 @@
 var gulp = require('gulp');
 
-gulp.task('default', ['build', 'watch', 'serve', 'open']);
+gulp.task('default', ['watch', 'build', 'serve', 'open']);

--- a/gulp/tasks/watch.js
+++ b/gulp/tasks/watch.js
@@ -1,5 +1,6 @@
 var gulp       = require('gulp');
 var livereload = require('gulp-livereload');
+var config     = require('../config');
 
 gulp.task('watch', function() {
 	var server = livereload();
@@ -8,8 +9,11 @@ gulp.task('watch', function() {
 		server.changed(file.path);
 	};
 
-	gulp.watch('src/javascript/**', ['browserify']);
 	gulp.watch('src/sass/**', ['compass']);
 	gulp.watch('src/images/**', ['images']);
 	gulp.watch(['build/**']).on('change', reload);
+
+	// Note: Javascript watching is handled by watchify
+	// in gulp/tasks/browserify.js, when this flag is true
+	config.isWatching = true;
 });

--- a/gulp/util/bundleLogger.js
+++ b/gulp/util/bundleLogger.js
@@ -1,0 +1,21 @@
+/* bundleLogger
+   ------------
+   Provides gulp style logs to the bundle method in browserify.js
+*/
+
+var gutil        = require('gulp-util');
+var prettyHrtime = require('pretty-hrtime');
+var startTime;
+
+module.exports = {
+	start: function() {
+		startTime = process.hrtime();
+		gutil.log('Running', gutil.colors.green("'bundle'") + '...');
+	},
+
+	end: function() {
+		var taskTime = process.hrtime(startTime);
+		var prettyTime = prettyHrtime(taskTime);
+		gutil.log('Finished', gutil.colors.green("'bundle'"), 'in', gutil.colors.magenta(prettyTime));
+	}
+};

--- a/package.json
+++ b/package.json
@@ -38,7 +38,10 @@
     "gulp-open": "~0.2.8",
     "gulp": "~3.6.0",
     "hbsfy": "~1.3.2",
-    "vinyl-source-stream": "~0.1.1"
+    "vinyl-source-stream": "~0.1.1",
+    "watchify": "~0.10.1",
+    "gulp-util": "~2.2.14",
+    "pretty-hrtime": "~0.2.1"
   },
   "dependencies": {
     "backbone": "~1.1.2",

--- a/src/javascript/view.coffee
+++ b/src/javascript/view.coffee
@@ -17,7 +17,7 @@ module.exports = Backbone.View.extend
 			description: 'Starter Gulp + Browserify project equipped to handle the following:'
 			tools: [
 				'Browserify-shim'
-				'Browserify'
+				'Browserify / Watchify'
 				'CoffeeScript'
 				'Compass'
 				'SASS'


### PR DESCRIPTION
This commit adds [watchify](https://github.com/substack/watchify) in place of **browserify** when files are being watched. Way faster rebuilds! (10x faster on bigger projects)

From the docs:

> [watchify] ... is exactly like a browserify ... except that it caches file contents and emits an 'update' event when a file changes. You should call w.bundle() after the 'update' event fires to generate a new bundle. Calling w.bundle() extra times past the first time will be much faster due to caching.

Resolves #13 
