### PR TITLE
Use require-dir to require tasks

### DIFF
--- a/gulp/index.js
+++ b/gulp/index.js
@@ -1,7 +1,4 @@
-var fs = require('fs');
-var onlyScripts = require('./util/scriptFilter');
-var tasks = fs.readdirSync('./gulp/tasks/').filter(onlyScripts);
+var requireDir = require('require-dir');
 
-tasks.forEach(function(task) {
-  require('./tasks/' + task);
-});
+// Require all tasks in gulp/tasks, including subfolders
+requireDir('./tasks', { recurse: true });

--- a/gulp/util/scriptFilter.js
+++ b/gulp/util/scriptFilter.js
@@ -1,7 +1,0 @@
-var path = require("path");
-
-// Filters out non .coffee and .js files. Prevents
-// accidental inclusion of possible hidden files
-module.exports = function(name) {
-  return /(\.(js|coffee)$)/i.test(path.extname(name));
-};

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "handlebars": "^1.3.0",
     "hbsfy": "~1.3.2",
     "pretty-hrtime": "~0.2.1",
+    "require-dir": "^0.1.0",
     "vinyl-source-stream": "~0.1.1",
     "watchify": "~0.10.1"
   },


### PR DESCRIPTION
- Better solution
- Allows importing tasks in subfolders, Fixes #21
