### PR TITLE
Modify browserify task for use with multiple bundles.

### DIFF
--- a/gulp/config.js
+++ b/gulp/config.js
@@ -2,40 +2,45 @@ var dest = "./build";
 var src = './src';
 
 module.exports = {
-  serverport: 3000,
   browserSync: {
     server: {
+      // We're serving the src folder as well
+      // for sass sourcemap linking
       baseDir: [dest, src]
     },
-    files: [dest + "/**", "!" + dest + "/**.map"]
+    files: [
+      dest + "/**",
+      // Exclude Map files
+      "!" + dest + "/**.map"
+    ]
   },
   sass: {
     src: src + "/sass/*.{sass, scss}",
-    dest: dest
-  },
-  scripts: {
-    src: src + "/javascript/**/*.js",
     dest: dest
   },
   images: {
     src: src + "/images/**",
     dest: dest + "/images"
   },
-  dist: {
-    root: dest
-  },
-  htdocs: {
-    src: src + "/htdocs/**",
-    dest: dest
-  },
   markup: {
     src: src + "/htdocs/**",
     dest: dest
   },
   browserify: {
-    entries: [src + "/javascript/app.coffee"],
+    // Enable source maps
+    debug: true,
+    // Additional file extentions to make optional
     extensions: ['.coffee', '.hbs'],
-    bundleName: "app.js",
-    dest: dest
+    // A separate bundle will be generated for each
+    // bundle config in the list below
+    bundleConfigs: [{
+      entries: './src/javascript/app.coffee',
+      dest: dest,
+      outputName: 'app.js'
+    }, {
+      entries: './src/javascript/head.coffee',
+      dest: dest,
+      outputName: 'head.js'
+    }]
   }
 };

--- a/gulp/tasks/browserify.js
+++ b/gulp/tasks/browserify.js
@@ -2,8 +2,10 @@
    ---------------
    Bundle javascripty things with browserify!
 
-   If the watch task is running, this uses watchify instead
-   of browserify for faster bundling using caching.
+   This task is set up to generate multiple separate bundles, from
+   different sources, and to use Watchify when run from the default task.
+
+   See browserify.bundleConfigs in gulp/config.js
 */
 
 var browserify   = require('browserify');
@@ -14,41 +16,64 @@ var handleErrors = require('../util/handleErrors');
 var source       = require('vinyl-source-stream');
 var config       = require('../config').browserify;
 
-gulp.task('browserify', function() {
-  var bundler = browserify({
-    // Required watchify args
-    cache: {}, packageCache: {}, fullPaths: true,
-    // Specify the entry point of your app
-    entries: config.entries,
-    // Add file extentions to make optional in your requires
-    extensions: config.extensions,
-    // Enable source maps!
-    debug: true
-  });
+gulp.task('browserify', function(callback) {
 
-  var bundle = function() {
-    // Log when bundling starts
-    bundleLogger.start();
+  var bundleQueue = config.bundleConfigs.length;
 
-    return bundler
-      .bundle()
-      // Report compile errors
-      .on('error', handleErrors)
-      // Use vinyl-source-stream to make the
-      // stream gulp compatible. Specifiy the
-      // desired output filename here.
-      .pipe(source(config.bundleName))
-      // Specify the output destination
-      .pipe(gulp.dest(config.dest))
-      // Log when bundling completes!
-      .on('end', bundleLogger.end);
+  var browserifyThis = function(bundleConfig) {
+
+    var bundler = browserify({
+      // Required watchify args
+      cache: {}, packageCache: {}, fullPaths: true,
+      // Specify the entry point of your app
+      entries: bundleConfig.entries,
+      // Add file extentions to make optional in your requires
+      extensions: config.extensions,
+      // Enable source maps!
+      debug: config.debug
+    });
+
+    var bundle = function() {
+      // Log when bundling starts
+      bundleLogger.start(bundleConfig.outputName);
+
+      return bundler
+        .bundle()
+        // Report compile errors
+        .on('error', handleErrors)
+        // Use vinyl-source-stream to make the
+        // stream gulp compatible. Specifiy the
+        // desired output filename here.
+        .pipe(source(bundleConfig.outputName))
+        // Specify the output destination
+        .pipe(gulp.dest(bundleConfig.dest))
+        .on('end', reportFinished);
+    };
+
+    if(global.isWatching) {
+      // Wrap with watchify and rebundle on changes
+      bundler = watchify(bundler);
+      // Rebundle on update
+      bundler.on('update', bundle);
+    }
+
+    var reportFinished = function() {
+      // Log when bundling completes
+      bundleLogger.end(bundleConfig.outputName)
+
+      if(bundleQueue) {
+        bundleQueue--;
+        if(bundleQueue === 0) {
+          // If queue is empty, tell gulp the task is complete.
+          // https://github.com/gulpjs/gulp/blob/master/docs/API.md#accept-a-callback
+          callback();
+        }
+      }
+    };
+
+    return bundle();
   };
 
-  if(global.isWatching) {
-    bundler = watchify(bundler);
-    // Rebundle with watchify on changes.
-    bundler.on('update', bundle);
-  }
-
-  return bundle();
+  // Start bundling with Browserify for each bundleConfig specified
+  config.bundleConfigs.forEach(browserifyThis);
 });

--- a/gulp/util/bundleLogger.js
+++ b/gulp/util/bundleLogger.js
@@ -8,14 +8,14 @@ var prettyHrtime = require('pretty-hrtime');
 var startTime;
 
 module.exports = {
-  start: function() {
+  start: function(filepath) {
     startTime = process.hrtime();
-    gutil.log('Running', gutil.colors.green("'bundle'") + '...');
+    gutil.log('Bundling', gutil.colors.green(filepath) + '...');
   },
 
-  end: function() {
+  end: function(filepath) {
     var taskTime = process.hrtime(startTime);
     var prettyTime = prettyHrtime(taskTime);
-    gutil.log('Finished', gutil.colors.green("'bundle'"), 'in', gutil.colors.magenta(prettyTime));
+    gutil.log('Bundled', gutil.colors.green(filepath), 'in', gutil.colors.magenta(prettyTime));
   }
 };

--- a/src/htdocs/index.html
+++ b/src/htdocs/index.html
@@ -3,11 +3,14 @@
   <head>
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-    <title>Gulp Playground</title>
-    <link rel="stylesheet" href="/app.css" />
+    <title>Gulp Starter</title>
+    <script src="head.js"></script>
+    <link rel="stylesheet" href="app.css" />
   </head>
 
   <body>
-    <script src="/app.js"></script>
+    <h1>Gulp All The Things!</h1>
+    <div id="content"></div>
+    <script src="app.js"></script>
   </body>
 </html>

--- a/src/javascript/app.coffee
+++ b/src/javascript/app.coffee
@@ -1,2 +1,3 @@
 View =  require './view'
-view = new View(el: 'body')
+view = new View(el: '#content')
+console.log 'app.js loaded!'

--- a/src/javascript/head.coffee
+++ b/src/javascript/head.coffee
@@ -1,0 +1,4 @@
+# require scripts like Modernizr, polyfills and other
+# js that needs to go in the <head> tag here.
+
+console.log 'head.js loaded!'

--- a/src/javascript/template.hbs
+++ b/src/javascript/template.hbs
@@ -1,4 +1,3 @@
-<h1>{{title}}</h1>
 <p>
   {{description}}
 </p>

--- a/src/javascript/view.coffee
+++ b/src/javascript/view.coffee
@@ -13,11 +13,11 @@ module.exports = Backbone.View.extend
 
   render: ->
     @$el.html @template
-      title: 'Gulp All The Things!'
       description: 'Starter Gulp + Browserify project equipped to handle the following:'
       tools: [
         'Browserify-shim'
         'Browserify / Watchify'
+        'BrowserSync'
         'CoffeeScript'
         'Compass'
         'SASS'


### PR DESCRIPTION
@solomonhawk @nhunzaker

How's this look? (man the line comments are noisy... but helpful for people I think) Is there a more node-ier way to tell when all streams in a list have emmited their 'end' event? Might be overthinking it. This works fine... 

Also, do you think this is getting to complicated for a starter kit? Should I move this to an "Advanced examples" subfolder in tasks? ¯\(°_o)/¯

Personally, I'd use this setup as my default.

~~Also, I'm going to refactor this a bit, and have a `shared.js` with jQuery and backbone in it, then have a `app.js` and an `admin.js` that rely on them, but exclude them from their bundles with the --external flag~~ (see: https://github.com/substack/node-browserify#multiple-bundles). **Update:** I could not get shared external dependencies working for the life of me. I'll try again later...
