### PR TITLE
Break out configuration settings into config file; implements #35 

### DIFF
--- a/gulp/config.coffee
+++ b/gulp/config.coffee
@@ -1,0 +1,44 @@
+dest = "./build"
+src  = './src'
+
+module.exports =
+  serverport: 3000
+  browserSync:
+    server:
+      # src is included for use with sass source maps
+      baseDir: [dest, src]
+    files: [
+      # Watch everything in build
+      "#{dest}/**",
+      # Exclude sourcemap files
+      "!#{dest}/**.map"
+    ]
+
+  sass:
+    src : "#{src}/sass/*.{sass, scss}"
+    dest: dest
+
+  scripts:
+    src : "#{src}/javascript/**/*.js"
+    dest: dest
+
+  images:
+    src : "#{src}/images/**"
+    dest: "#{dest}/images"
+
+  dist:
+    root: dest
+
+  htdocs:
+    src: "#{src}/htdocs/**"
+    dest: dest
+
+  markup:
+    src: "#{src}/htdocs/**"
+    dest:"#{dest}"
+
+  browserify:
+    entries: ["#{src}/javascript/app.coffee"]
+    extensions: ['.coffee', '.hbs']
+    bundleName: "app.js"
+    dest: dest

--- a/gulp/tasks/browserSync.js
+++ b/gulp/tasks/browserSync.js
@@ -1,17 +1,7 @@
 var browserSync = require('browser-sync');
 var gulp        = require('gulp');
+var config      = require('../config').browserSync;
 
 gulp.task('browserSync', ['build'], function() {
-  browserSync({
-    server: {
-      // src is included for use with sass source maps
-      baseDir: ['build', 'src']
-    },
-    files: [
-      // Watch everything in build
-      "build/**",
-      // Exclude sourcemap files
-      "!build/**.map"
-    ]
-  });
+  browserSync(config);
 });

--- a/gulp/tasks/browserify.js
+++ b/gulp/tasks/browserify.js
@@ -12,15 +12,16 @@ var bundleLogger = require('../util/bundleLogger');
 var gulp         = require('gulp');
 var handleErrors = require('../util/handleErrors');
 var source       = require('vinyl-source-stream');
+var config       = require('../config').browserify;
 
 gulp.task('browserify', function() {
   var bundler = browserify({
     // Required watchify args
     cache: {}, packageCache: {}, fullPaths: true,
     // Specify the entry point of your app
-    entries: ['./src/javascript/app.coffee'],
+    entries: config.entries,
     // Add file extentions to make optional in your requires
-    extensions: ['.coffee', '.hbs'],
+    extensions: config.extensions,
     // Enable source maps!
     debug: true
   });
@@ -36,9 +37,9 @@ gulp.task('browserify', function() {
       // Use vinyl-source-stream to make the
       // stream gulp compatible. Specifiy the
       // desired output filename here.
-      .pipe(source('app.js'))
+      .pipe(source(config.bundleName))
       // Specify the output destination
-      .pipe(gulp.dest('./build/'))
+      .pipe(gulp.dest(config.dest))
       // Log when bundling completes!
       .on('end', bundleLogger.end);
   };

--- a/gulp/tasks/images.js
+++ b/gulp/tasks/images.js
@@ -1,12 +1,11 @@
 var changed    = require('gulp-changed');
 var gulp       = require('gulp');
 var imagemin   = require('gulp-imagemin');
+var config     = require('../config').images;
 
 gulp.task('images', function() {
-  var dest = './build/images';
-
-  return gulp.src('./src/images/**')
-    .pipe(changed(dest)) // Ignore unchanged files
+  return gulp.src(config.src)
+    .pipe(changed(config.dest)) // Ignore unchanged files
     .pipe(imagemin()) // Optimize
-    .pipe(gulp.dest(dest));
+    .pipe(gulp.dest(config.dest));
 });

--- a/gulp/tasks/markup.js
+++ b/gulp/tasks/markup.js
@@ -1,6 +1,7 @@
 var gulp = require('gulp');
+var config = require('../config').markup
 
 gulp.task('markup', function() {
-  return gulp.src('src/htdocs/**')
-    .pipe(gulp.dest('build'));
+  return gulp.src(config.src)
+    .pipe(gulp.dest(config.dest));
 });

--- a/gulp/tasks/sass.js
+++ b/gulp/tasks/sass.js
@@ -1,9 +1,10 @@
 var gulp = require('gulp');
 var sass = require('gulp-ruby-sass');
 var handleErrors = require('../util/handleErrors');
+var config=require('../config').sass;
 
 gulp.task('sass', ['images'], function () {
-  return gulp.src('src/sass/*.{sass, scss}')
+  return gulp.src(config.src)
     .pipe(sass({
       compass: true,
       bundleExec: true,
@@ -11,5 +12,5 @@ gulp.task('sass', ['images'], function () {
       sourcemapPath: '../sass'
     }))
     .on('error', handleErrors)
-    .pipe(gulp.dest('build'));
+    .pipe(gulp.dest(config.dest));
 });

--- a/gulp/tasks/watch.js
+++ b/gulp/tasks/watch.js
@@ -3,10 +3,11 @@
    - gulp/tasks/browserSync.js watches and reloads compiled files
 */
 
-var gulp = require('gulp');
+var gulp  = require('gulp');
+var config= require('../config');
 
 gulp.task('watch', ['setWatch', 'browserSync'], function() {
-  gulp.watch('src/sass/**', ['sass']);
-  gulp.watch('src/images/**', ['images']);
-  gulp.watch('src/htdocs/**', ['markup']);
+  gulp.watch(config.sass.src,   ['sass']);
+  gulp.watch(config.images.src, ['images']);
+  gulp.watch(config.markup.src, ['markup']);
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -11,6 +11,7 @@
   when you run `gulp`.
 */
 
+require('coffee-script/register');
 var requireDir = require('require-dir');
 
 // Require all tasks in gulp/tasks, including subfolders

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "pretty-hrtime": "~0.2.1",
     "require-dir": "^0.1.0",
     "vinyl-source-stream": "~0.1.1",
-    "watchify": "~1.0.2"
+    "watchify": "~1.0.2",
+    "coffee-script": "^1.8.0"
   },
   "dependencies": {
     "backbone": "~1.1.2",


### PR DESCRIPTION
Task configuration is now stored in `gulp/config.coffee`.
Changed tasks so that they `require` this file and take settings from there.
