### PR TITLE
Provides a better error message

### DIFF
--- a/gulp/util/handleErrors.js
+++ b/gulp/util/handleErrors.js
@@ -7,7 +7,7 @@ module.exports = function() {
   // Send error to notification center with gulp-notify
   notify.onError({
     title: "Compile Error",
-    message: "<%= error.message %>"
+    message: "<%= error %>"
   }).apply(this, args);
 
   // Keep gulp from hanging on this task


### PR DESCRIPTION
Having error.message sometimes provides insufficient feedback: `gulp-notify: [Compile Error] Unexpected token`

Without the .message you get a more details error:

```
./app/assets/coffee/app.coffee:1
alert 'hello world'
      ^
ParseError: Unexpected token
```

I know it's a bad example but you get the point I hope. Let me know if you disagree.
