### PR TITLE
[#422] add watchOptions to browserSync config

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,16 @@ browserSync: {
 }
 ```
 
+**If you need to turn on polling within webpack-dev-middleware**, specify `watchOptions` within this section, too.
+```js
+browserSync: {
+  watchOptions: {
+    poll: true,
+    aggregateTimeout: 300
+  }
+}
+```
+
 ### javascripts
 Under the hood, JS is compiled with webpack 2 with a heavily customized webpack file to get you up and running with little to no configuration. An API for configuring some of the most commonly accessed options are exposed, along with some other helpers for scoping to environment. Additionally, you can get full access to modify Blendid's `webpackConfig` via the [`customizeWebpackConfig`](#customizeWebpackConfig) option.
 

--- a/gulpfile.js/tasks/browserSync.js
+++ b/gulpfile.js/tasks/browserSync.js
@@ -36,6 +36,7 @@ var browserSyncTask = function() {
   server.middleware = [
     require('webpack-dev-middleware')(compiler, {
       stats: 'errors-only',
+      watchOptions: TASK_CONFIG.browserSync.watchOptions || {},
       publicPath: pathToUrl('/', webpackConfig.output.publicPath)
     }),
     require('webpack-hot-middleware')(compiler)


### PR DESCRIPTION
_Submitting a new PR as I think this got lost in the Blendid 4.0 release._

Addresses #422 -- allows for watchOptions to be specified within task-config.js and updates the readme with an example. (note that watch.gulpWatch isn't in the readme, which goes hand-in-hand with this change).

Since fsnotify file system events won't trigger in any VirtualBox shared folders, browserSync needs watchOptions.poll: true in order to know to re-compile when any source files are changed.