### PR TITLE
Add an additional `webroot` path setting, used by the rev tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ File structure is configued through a **config/path-config.json** file. This fil
 
 This file specifies the `src` and `dest` root directories, and `src` and `dest` for each task, relative to the configured root.
 
+If the public webroot directory is different from the main `dest` directory, you may also specify the `webroot` setting, with the name of the subdirectory, e.g. `public_html`.
+
 A minimal setup might look someting like this:
 
 ```json

--- a/gulpfile.js/lib/webpack-multi-config.js
+++ b/gulpfile.js/lib/webpack-multi-config.js
@@ -75,8 +75,8 @@ module.exports = function (env) {
 
   if (env === 'production') {
     if (rev) {
-      var srcPath = PATH_CONFIG.rootPath ?
-        path.relative(PATH_CONFIG.rootPath, PATH_CONFIG.javascripts.dest) :
+      var srcPath = PATH_CONFIG.webroot ?
+        path.relative(PATH_CONFIG.webroot, PATH_CONFIG.javascripts.dest) :
         PATH_CONFIG.javascripts.dest
       webpackConfig.plugins.push(new webpackManifest(srcPath, PATH_CONFIG.dest))
     }

--- a/gulpfile.js/lib/webpack-multi-config.js
+++ b/gulpfile.js/lib/webpack-multi-config.js
@@ -75,7 +75,10 @@ module.exports = function (env) {
 
   if (env === 'production') {
     if (rev) {
-      webpackConfig.plugins.push(new webpackManifest(PATH_CONFIG.javascripts.dest, PATH_CONFIG.dest))
+      var srcPath = PATH_CONFIG.rootPath ?
+        path.relative(PATH_CONFIG.rootPath, PATH_CONFIG.javascripts.dest) :
+        PATH_CONFIG.javascripts.dest
+      webpackConfig.plugins.push(new webpackManifest(srcPath, PATH_CONFIG.dest))
     }
 
     const uglifyConfig = TASK_CONFIG.javascripts.production.uglifyJsPlugin

--- a/gulpfile.js/tasks/rev/rev-assets.js
+++ b/gulpfile.js/tasks/rev/rev-assets.js
@@ -5,10 +5,10 @@ var revNapkin = require('gulp-rev-napkin');
 
 // 1) Add md5 hashes to assets referenced by CSS and JS files
 gulp.task('rev-assets', function() {
-  var srcPath = path.resolve(process.env.PWD, PATH_CONFIG.dest, PATH_CONFIG.rootPath || '')
+  var srcPath = path.resolve(process.env.PWD, PATH_CONFIG.dest, PATH_CONFIG.webroot || '')
 
   // Ignore files that may reference assets. We'll rev them next.
-  var ignoreThese = '!' + path.resolve(srcPath, '**/*+(css|js|map|json|html|php)')
+  var ignoreThese = '!' + path.resolve(srcPath, '**/*+(css|js|map|json|html)')
 
   return gulp.src([path.resolve(srcPath, '**/*'), ignoreThese])
     .pipe(rev())

--- a/gulpfile.js/tasks/rev/rev-assets.js
+++ b/gulpfile.js/tasks/rev/rev-assets.js
@@ -8,7 +8,7 @@ gulp.task('rev-assets', function() {
   var srcPath = path.resolve(process.env.PWD, PATH_CONFIG.dest, PATH_CONFIG.rootPath || '')
 
   // Ignore files that may reference assets. We'll rev them next.
-  var ignoreThese = '!' + path.resolve(srcPath, '**/*+(css|js|map|json|html)')
+  var ignoreThese = '!' + path.resolve(srcPath, '**/*+(css|js|map|json|html|php)')
 
   return gulp.src([path.resolve(srcPath, '**/*'), ignoreThese])
     .pipe(rev())

--- a/gulpfile.js/tasks/rev/rev-assets.js
+++ b/gulpfile.js/tasks/rev/rev-assets.js
@@ -5,12 +5,14 @@ var revNapkin = require('gulp-rev-napkin');
 
 // 1) Add md5 hashes to assets referenced by CSS and JS files
 gulp.task('rev-assets', function() {
-  // Ignore files that may reference assets. We'll rev them next.
-  var ignoreThese = '!' + path.resolve(process.env.PWD, PATH_CONFIG.dest,'**/*+(css|js|map|json|html)')
+  var srcPath = path.resolve(process.env.PWD, PATH_CONFIG.dest, PATH_CONFIG.rootPath || '')
 
-  return gulp.src([path.resolve(process.env.PWD, PATH_CONFIG.dest,'**/*'), ignoreThese])
+  // Ignore files that may reference assets. We'll rev them next.
+  var ignoreThese = '!' + path.resolve(srcPath, '**/*+(css|js|map|json|html)')
+
+  return gulp.src([path.resolve(srcPath, '**/*'), ignoreThese])
     .pipe(rev())
-    .pipe(gulp.dest(PATH_CONFIG.dest))
+    .pipe(gulp.dest(srcPath))
     .pipe(revNapkin({ verbose: false, force: true }))
     .pipe(rev.manifest(path.resolve(process.env.PWD, PATH_CONFIG.dest, 'rev-manifest.json'), {merge: true}))
     .pipe(gulp.dest(''))

--- a/gulpfile.js/tasks/rev/rev-css.js
+++ b/gulpfile.js/tasks/rev/rev-css.js
@@ -3,12 +3,14 @@ var path      = require('path')
 var rev       = require('gulp-rev')
 var revNapkin = require('gulp-rev-napkin')
 
-// 4) Rev and compress CSS and JS files (this is done after assets, so that if a
+// 4) Rev and compress CSS files (this is done after assets, so that if a
 //    referenced asset hash changes, the parent hash will change as well
-gulp.task('rev-css', function(){
-  return gulp.src(path.resolve(process.env.PWD, PATH_CONFIG.dest,'**/*.css'))
+gulp.task('rev-css', function() {
+  var srcPath = path.resolve(process.env.PWD, PATH_CONFIG.dest, PATH_CONFIG.rootPath || '')
+
+  return gulp.src(path.resolve(srcPath, '**/*.css'))
     .pipe(rev())
-    .pipe(gulp.dest(PATH_CONFIG.dest))
+    .pipe(gulp.dest(srcPath))
     .pipe(revNapkin({verbose: false, force: true}))
     .pipe(rev.manifest(path.resolve(process.env.PWD, PATH_CONFIG.dest, 'rev-manifest.json'), {merge: true}))
     .pipe(gulp.dest(''))

--- a/gulpfile.js/tasks/rev/rev-css.js
+++ b/gulpfile.js/tasks/rev/rev-css.js
@@ -6,7 +6,7 @@ var revNapkin = require('gulp-rev-napkin')
 // 4) Rev and compress CSS files (this is done after assets, so that if a
 //    referenced asset hash changes, the parent hash will change as well
 gulp.task('rev-css', function() {
-  var srcPath = path.resolve(process.env.PWD, PATH_CONFIG.dest, PATH_CONFIG.rootPath || '')
+  var srcPath = path.resolve(process.env.PWD, PATH_CONFIG.dest, PATH_CONFIG.stylesheets.dest || '')
 
   return gulp.src(path.resolve(srcPath, '**/*.css'))
     .pipe(rev())


### PR DESCRIPTION
For [my use case](https://github.com/vigetlabs/blendid/issues/303#issuecomment-304552882) of copying template files to a location outside of the public webroot using the `html` task, I needed a way of adjusting the asset URIs that the `rev` tasks generate – for example if `dest` is `./dist` and `stylesheets.dest` is `public/assets/css`, I would end up with an entry in rev-manifest.json like `"public/assets/css/site.css": "public/assets/css/site-1234567890.css"`, which obviously wouldn't match against the actual asset URL in my markup.

What I did was add an additional `webroot` option to `path-config.json`. If that is set, it is considered the base path of the final URIs that are stored in `rev-manifest.json`. Using my example above, I would set `"webroot": "public"` and end up with `"assets/css/site.css": "assets/css/site-1234567890.css"`. 

I went back and forth a few times on what to call that new setting (`assetsRoot`, `rootPath`....), so feel free to rename it to whatever you feel is most appropriate if you decide to accept this PR.