### PR TITLE
Fixed bin script module resolving

### DIFF
--- a/bin/blendid.js
+++ b/bin/blendid.js
@@ -1,10 +1,15 @@
 #!/usr/bin/env node
-const additionalArgs = require('minimist')(process.argv.slice(2))._
+const path = require('path');
 
-let args = ['--gulpfile', 'node_modules/blendid/gulpfile.js']
+const additionalArgs = require('minimist')(process.argv.slice(2))._
+const blendidEntryFile = require.resolve('blendid');
+const gulpModulePath = path.dirname(require.resolve('gulp'));
+const gulpBinaryFile = path.join(gulpModulePath, '/bin/gulp');
+
+let args = ['--gulpfile', blendidEntryFile]
 
 if(additionalArgs.length) {
   args = args.concat(additionalArgs)
 }
 
-require('child_process').fork('node_modules/gulp/bin/gulp', args)
+require('child_process').fork(gulpBinaryFile, args)


### PR DESCRIPTION
When using a tool like Lerna with hoisting (common dependencies installed in project root `node_modules` and not sub-project `node_modules`) or upcoming Yarn workspaces support, the resolving of `blendid` gulp main task file as well as gulp itself is broken.

The current script assumes resolution in the package directory while with these kind of tool, it get installed higher in the project hierarchy.

To solve this, we switched to `require.resolve` to resolve the actual location of the required files. This uses Node.js resolution mechanism to find the right package location.

The downside is that `require.resolve` returns the actual entry file and not the base package directory (`blendid/gulpfile.js/index.js` for `require.resolve('blendid')`). The implications is that if the entry file changes for `blendid` or `gulp`, the script is broken.

All in all, since we depends explicitly on particular versions of gulp, it should not be a problem to keep it in sync.