### PR TITLE
Prevent `browserSync.server.middleware` from being ovewritten completely

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,24 @@ browserSync: {
 }
 ```
 
+**If you need to add extra middlewares**, specify `extraMiddlewares` within the `server` subsection of this section.
+```js
+browserSync: {
+  server: {
+    extraMiddlewares: [historyApiFallbackMiddleware],
+  },
+},
+```
+
+**If you need to override completely all server's middleware**, specify `middleware` within the `server` subsection of this section.
+```js
+browserSync: {
+  server: {
+    middleware: [/* On your own! Note that default 'webpack-dev-middleware' will not be enabled using this option */],
+  },
+}
+```
+
 ### javascripts
 Under the hood, JS is compiled with webpack 3 with a heavily customized webpack file to get you up and running with little to no configuration. An API for configuring some of the most commonly accessed options are exposed, along with some other helpers for scoping to environment. Additionally, you can get full access to modify Blendid's `webpackConfig` via the [`customizeWebpackConfig`](#customizewebpackconfig) option.
 

--- a/gulpfile.js/tasks/browserSync.js
+++ b/gulpfile.js/tasks/browserSync.js
@@ -33,14 +33,14 @@ var browserSyncTask = function() {
 
   var server = TASK_CONFIG.browserSync.proxy || TASK_CONFIG.browserSync.server;
 
-  server.middleware = [
+  server.middleware = server.middleware || [
     require('webpack-dev-middleware')(compiler, {
       stats: 'errors-only',
       watchOptions: TASK_CONFIG.browserSync.watchOptions || {},
       publicPath: pathToUrl('/', webpackConfig.output.publicPath)
     }),
     require('webpack-hot-middleware')(compiler)
-  ]
+  ].concat(server.extraMiddlewares || [])
 
   browserSync.init(TASK_CONFIG.browserSync)
 }


### PR DESCRIPTION
Currently, the `server.middleware` config option is completely set in stone and there is no possibility to extend it. However, to be able to make React Router `<BrowserRouter>` (opposed to `<HashRouter>`) to work, one need to add a `browserSync` middleware.

To overcome the problem, two mecanisms has been added to solve this. First, if the `browserSync.server.middleware` is already defined, blendid does not try to override it anymore.

If not present, default middleware (`webpack-dev-middleware`) is used. Furthermore, the default mdidlewares from `browserSync.server.middleware` are concatenated with the ones find on config `browserSync.server.extraMiddlewares` (defaults to `[]` when none defined).

Fixed problem running on Node v8 (at least in development mode via `yarn link`) by updating `require-dir` to latest version (`0.3.2`).