### PR TITLE
Replace rev'd filenames in Twig, Handlebars, & PHP templates

### DIFF
--- a/gulpfile.js/tasks/rev/rev-assets.js
+++ b/gulpfile.js/tasks/rev/rev-assets.js
@@ -6,7 +6,7 @@ var revNapkin = require('gulp-rev-napkin');
 // 1) Add md5 hashes to assets referenced by CSS and JS files
 gulp.task('rev-assets', function() {
   // Ignore files that may reference assets. We'll rev them next.
-  var ignoreThese = '!' + path.resolve(process.env.PWD, PATH_CONFIG.dest,'**/*+(css|js|map|json|html|hbs|twig)')
+  var ignoreThese = '!' + path.resolve(process.env.PWD, PATH_CONFIG.dest,'**/*+(css|js|map|json|html|php|hbs|twig)')
 
   return gulp.src([path.resolve(process.env.PWD, PATH_CONFIG.dest,'**/*'), ignoreThese])
     .pipe(rev())

--- a/gulpfile.js/tasks/rev/rev-assets.js
+++ b/gulpfile.js/tasks/rev/rev-assets.js
@@ -6,7 +6,7 @@ var revNapkin = require('gulp-rev-napkin');
 // 1) Add md5 hashes to assets referenced by CSS and JS files
 gulp.task('rev-assets', function() {
   // Ignore files that may reference assets. We'll rev them next.
-  var ignoreThese = '!' + path.resolve(process.env.PWD, PATH_CONFIG.dest,'**/*+(css|js|map|json|html)')
+  var ignoreThese = '!' + path.resolve(process.env.PWD, PATH_CONFIG.dest,'**/*+(css|js|map|json|html|hbs|twig)')
 
   return gulp.src([path.resolve(process.env.PWD, PATH_CONFIG.dest,'**/*'), ignoreThese])
     .pipe(rev())

--- a/gulpfile.js/tasks/rev/update-html.js
+++ b/gulpfile.js/tasks/rev/update-html.js
@@ -10,7 +10,7 @@ gulp.task('update-html', function(){
   return gulp.src(path.resolve(process.env.PWD, PATH_CONFIG.dest, PATH_CONFIG.html.dest, '**/*'))
     .pipe(revReplace({
       manifest: manifest,
-      replaceInExtensions: ['.html', '.hbs', '.twig', '.json']
+      replaceInExtensions: ['.json', '.html', '.php', '.hbs', '.twig']
     }))
     .pipe(gulp.dest(path.resolve(process.env.PWD, PATH_CONFIG.dest, PATH_CONFIG.html.dest)))
 })

--- a/gulpfile.js/tasks/rev/update-html.js
+++ b/gulpfile.js/tasks/rev/update-html.js
@@ -10,7 +10,7 @@ gulp.task('update-html', function(){
   return gulp.src(path.resolve(process.env.PWD, PATH_CONFIG.dest, PATH_CONFIG.html.dest, '**/*'))
     .pipe(revReplace({
       manifest: manifest,
-      replaceInExtensions: ['.js', '.css', '.html', '.hbs', '.twig']
+      replaceInExtensions: ['.html', '.hbs', '.twig', '.json']
     }))
     .pipe(gulp.dest(path.resolve(process.env.PWD, PATH_CONFIG.dest, PATH_CONFIG.html.dest)))
 })

--- a/gulpfile.js/tasks/rev/update-html.js
+++ b/gulpfile.js/tasks/rev/update-html.js
@@ -7,7 +7,7 @@ var path       = require('path')
 // 5) Update asset references in HTML
 gulp.task('update-html', function(){
   var manifest = gulp.src(path.resolve(process.env.PWD, PATH_CONFIG.dest, "rev-manifest.json"))
-  return gulp.src(path.resolve(process.env.PWD, PATH_CONFIG.dest, PATH_CONFIG.html.dest, '**/*.html'))
+  return gulp.src(path.resolve(process.env.PWD, PATH_CONFIG.dest, PATH_CONFIG.html.dest, '**/*.{' + TASK_CONFIG.html.extensions + '}'))
     .pipe(revReplace({ manifest: manifest }))
     .pipe(gulp.dest(path.resolve(process.env.PWD, PATH_CONFIG.dest, PATH_CONFIG.html.dest)))
 })

--- a/gulpfile.js/tasks/rev/update-html.js
+++ b/gulpfile.js/tasks/rev/update-html.js
@@ -7,7 +7,10 @@ var path       = require('path')
 // 5) Update asset references in HTML
 gulp.task('update-html', function(){
   var manifest = gulp.src(path.resolve(process.env.PWD, PATH_CONFIG.dest, "rev-manifest.json"))
-  return gulp.src(path.resolve(process.env.PWD, PATH_CONFIG.dest, PATH_CONFIG.html.dest, '**/*.{' + TASK_CONFIG.html.extensions + '}'))
-    .pipe(revReplace({ manifest: manifest }))
+  return gulp.src(path.resolve(process.env.PWD, PATH_CONFIG.dest, PATH_CONFIG.html.dest, '**/*'))
+    .pipe(revReplace({
+      manifest: manifest,
+      replaceInExtensions: ['.js', '.css', '.html', '.hbs', '.twig']
+    }))
     .pipe(gulp.dest(path.resolve(process.env.PWD, PATH_CONFIG.dest, PATH_CONFIG.html.dest)))
 })


### PR DESCRIPTION
Currently the `rev` task only replaces asset urls with their hashed counterparts in .html files. This expands that behavior to include .twig, .hbs, & .php files, making it work with various common CMSs.

This replaces my previous PR #446, in which I accidentally used the wrong source branch.