### PR TITLE
fixes init task breaking after 4.4.0 release

### DIFF
--- a/gulpfile.js/lib/compileLogger.js
+++ b/gulpfile.js/lib/compileLogger.js
@@ -17,6 +17,6 @@ module.exports = function(err, stats) {
   } else {
     var compileTime = prettifyTime(stats.endTime - stats.startTime)
     log(colors[statColor](stats))
-    console.log('Compiled with', colors.cyan('webpack'), 'in', colors.magenta(compileTime))
+    log('Compiled with', colors.cyan('webpack'), 'in', colors.magenta(compileTime))
   }
 }

--- a/gulpfile.js/tasks/http2-upgrade.js
+++ b/gulpfile.js/tasks/http2-upgrade.js
@@ -9,10 +9,10 @@ gulp.task('http2-upgrade', function() {
   del([path.resolve(process.env.PWD, PATH_CONFIG.src, PATH_CONFIG.stylesheets.src)], { force: true })
   log(colors.green('Cleaned stylesheets directory'))
 
-  const configStream = gulp.src('extras/http2/**/*')
+  const configStream = gulp.src('../extras/http2/**/*')
     .pipe(gulp.dest(process.env.PWD))
 
-  const srcStream = gulp.src(['src/stylesheets', 'src/javascripts', 'src/html'])
+  const srcStream = gulp.src(['../src/stylesheets', '../src/javascripts', '../src/html'])
    .pipe(gulp.dest(path.join(process.env.PWD, PATH_CONFIG.src)))
 
   log(colors.green('Created HTTP/2 ready stylesheets directory'))

--- a/gulpfile.js/tasks/init-config.js
+++ b/gulpfile.js/tasks/init-config.js
@@ -5,7 +5,7 @@ var path = require('path')
 var merge = require('merge-stream')
 
 gulp.task('init-config', function() {
-  var configStream = gulp.src(['gulpfile.js/path-config.json', 'gulpfile.js/task-config.js'])
+  var configStream = gulp.src(['./path-config.json', './task-config.js'])
     .pipe(gulp.dest(path.join(process.env.PWD, 'config')))
 
   log(colors.green('Adding default path-config.json and task-config.js files to ./config/'))

--- a/gulpfile.js/tasks/init-craft.js
+++ b/gulpfile.js/tasks/init-craft.js
@@ -15,7 +15,7 @@ gulp.task('init-craft', function() {
   log(colors.green('Added gulpRev plugin to craft/plugins/gulprev!'))
   log(colors.green('Created config/path-config.json'))
   log(colors.green('Created config/task-config.js'))
-  console.log(
+  log(
 colors.green(`Blendid is configured for Craft!
 
 Next Steps

--- a/gulpfile.js/tasks/init-craft.js
+++ b/gulpfile.js/tasks/init-craft.js
@@ -5,10 +5,10 @@ const mergeStream = require('merge-stream')
 const path = require('path')
 
 gulp.task('init-craft', function() {
-  const configStream = gulp.src(['extras/craft/**/*', '*!ASSET-README.md'])
+  const configStream = gulp.src(['../extras/craft/**/*', '*!ASSET-README.md'])
     .pipe(gulp.dest(process.env.PWD))
 
-  const srcStream = gulp.src(['src/**/*', '*.gitkeep', '!src/html{,/**}', '!src/static{,/**}'])
+  const srcStream = gulp.src(['../src/**/*', '*.gitkeep', '!../src/html{,/**}', '!../src/static{,/**}'])
     .pipe(gulp.dest(path.join(process.env.PWD, PATH_CONFIG.src)))
 
 

--- a/gulpfile.js/tasks/init-drupal.js
+++ b/gulpfile.js/tasks/init-drupal.js
@@ -9,14 +9,14 @@ const path = require('path')
 gulp.task('init-drupal', function() {
   const envBasename = path.basename(process.env.PWD)
 
-  const configStream = gulp.src(['extras/drupal/**/*', '!extras/drupal/src/', '!extras/drupal/src/**/*', '!**/README.md'])
+  const configStream = gulp.src(['../extras/drupal/**/*', '!../extras/drupal/src/', '!../extras/drupal/src/**/*', '!**/README.md'])
     .pipe(rename(function (filepath) {
       filepath.basename = filepath.basename.replace('THEMENAME', envBasename);
     }))
     .pipe(replace('THEMENAME', envBasename))
     .pipe(gulp.dest(process.env.PWD))
 
-  const srcStream = gulp.src(['extras/drupal/src/**/*', '*.gitkeep'])
+  const srcStream = gulp.src(['../extras/drupal/src/**/*', '*.gitkeep'])
     .pipe(gulp.dest(path.join(process.env.PWD, PATH_CONFIG.src)))
 
   log(colors.green('Created config/path-config.json'))

--- a/gulpfile.js/tasks/init-drupal.js
+++ b/gulpfile.js/tasks/init-drupal.js
@@ -26,7 +26,7 @@ gulp.task('init-drupal', function() {
   log(colors.green('Created '+ envBasename +'.info.yml'))
   log(colors.green('Created '+ envBasename +'.libraries.yml'))
   log(colors.green('Created '+ envBasename +'.theme'))
-  console.log(
+  log(
 colors.green(`Blendid is configured for Drupal!
 
 Next Steps

--- a/gulpfile.js/tasks/init-rails.js
+++ b/gulpfile.js/tasks/init-rails.js
@@ -3,7 +3,7 @@ var log = require('fancy-log')
 var colors = require('ansi-colors')
 
 gulp.task('init-rails', function() {
-  var stream = gulp.src(['extras/rails/**/*', '*!README.md'])
+  var stream = gulp.src(['../extras/rails/**/*', '*!README.md'])
     .pipe(gulp.dest(process.env.PWD))
 
   log(colors.green('Created app/helpers/blendid_asset_helper.rb'))

--- a/gulpfile.js/tasks/init-rails.js
+++ b/gulpfile.js/tasks/init-rails.js
@@ -9,7 +9,7 @@ gulp.task('init-rails', function() {
   log(colors.green('Created app/helpers/blendid_asset_helper.rb'))
   log(colors.green('Created config/initializers/blendid.rb'))
   log(colors.green('Created config/deploy.rb.example'))
-  console.log(
+  log(
 colors.yellow(`
 
 Using Capistrano? Add the following to deploy.rb so assets will compile on deploy:

--- a/gulpfile.js/tasks/init.js
+++ b/gulpfile.js/tasks/init.js
@@ -8,7 +8,7 @@ gulp.task('init', function() {
   var defaultStream = gulp.src(['../extras/default/**/*'])
     .pipe(gulp.dest(process.env.PWD))
 
-  var configStream = gulp.src(['./path-config.json', 'gulpfile.js/task-config.js'])
+  var configStream = gulp.src(['./path-config.json', './task-config.js'])
     .pipe(gulp.dest(path.join(process.env.PWD, 'config')))
 
   var srcStream = gulp.src(['../src/**/*', '*.gitkeep'])

--- a/gulpfile.js/tasks/init.js
+++ b/gulpfile.js/tasks/init.js
@@ -15,7 +15,7 @@ gulp.task('init', function() {
     .pipe(gulp.dest(path.join(process.env.PWD, PATH_CONFIG.src)))
 
   log(colors.green('Generating default Blendid project files'))
-  console.log(colors.yellow(`
+  log(colors.yellow(`
 To start the dev server:
 `), colors.magenta(`
 yarn run blendid

--- a/gulpfile.js/tasks/init.js
+++ b/gulpfile.js/tasks/init.js
@@ -5,13 +5,13 @@ var path = require('path')
 var merge = require('merge-stream')
 
 gulp.task('init', function() {
-  var defaultStream = gulp.src(['extras/default/**/*'])
+  var defaultStream = gulp.src(['../extras/default/**/*'])
     .pipe(gulp.dest(process.env.PWD))
 
-  var configStream = gulp.src(['gulpfile.js/path-config.json', 'gulpfile.js/task-config.js'])
+  var configStream = gulp.src(['./path-config.json', 'gulpfile.js/task-config.js'])
     .pipe(gulp.dest(path.join(process.env.PWD, 'config')))
 
-  var srcStream = gulp.src(['src/**/*', '*.gitkeep'])
+  var srcStream = gulp.src(['../src/**/*', '*.gitkeep'])
     .pipe(gulp.dest(path.join(process.env.PWD, PATH_CONFIG.src)))
 
   log(colors.green('Generating default Blendid project files'))


### PR DESCRIPTION
relatively references correct files and directories needed for `gulp.dest` to build to in all init tasks.

strangely, i don't know how this ever worked before.

fixes #527 