### PR TITLE
Fix/run blendid after bin fix

### DIFF
--- a/bin/blendid.js
+++ b/bin/blendid.js
@@ -2,11 +2,11 @@
 const path = require('path')
 
 const additionalArgs = require('minimist')(process.argv.slice(2))._
-const blendidEntryFile = path.resolve(__dirname, '../gulpfile.js/index.js')
+const blendidEntryDir = path.resolve(__dirname, '../gulpfile.js')
 const gulpModulePath = path.dirname(require.resolve('gulp'))
 const gulpBinaryFile = path.join(gulpModulePath, '/bin/gulp')
 
-let args = ['--gulpfile', blendidEntryFile]
+let args = ['--gulpfile', blendidEntryDir]
 
 if(additionalArgs.length) {
   args = args.concat(additionalArgs)

--- a/bin/blendid.js
+++ b/bin/blendid.js
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
-const path = require('path');
+const path = require('path')
 
 const additionalArgs = require('minimist')(process.argv.slice(2))._
-const blendidEntryFile = require.resolve('blendid');
-const gulpModulePath = path.dirname(require.resolve('gulp'));
-const gulpBinaryFile = path.join(gulpModulePath, '/bin/gulp');
+const blendidEntryFile = path.resolve(__dirname, '../gulpfile.js/index.js')
+const gulpModulePath = path.dirname(require.resolve('gulp'))
+const gulpBinaryFile = path.join(gulpModulePath, '/bin/gulp')
 
 let args = ['--gulpfile', blendidEntryFile]
 

--- a/extras/tasks/iconFont/index.js
+++ b/extras/tasks/iconFont/index.js
@@ -7,16 +7,17 @@ var generateIconSass = require('./generateIconSass')
 var handleErrors     = require('../../lib/handleErrors')
 var package          = require('../../../package.json')
 var path             = require('path')
+var projectPath      = require('../../lib/projectPath')
 var url              = require('url')
 
-var fontPath = path.resolve(process.env.PWD, config.root.dest, config.tasks.iconFont.dest)
-var cssPath = path.resolve(process.env.PWD, config.root.dest, config.tasks.css.dest)
+var fontPath = projectPath(config.root.dest, config.tasks.iconFont.dest)
+var cssPath = projectPath(config.root.dest, config.tasks.css.dest)
 
 var settings = {
   name: package.name + ' icons',
-  src: path.resolve(process.env.PWD, config.root.src, config.tasks.iconFont.src, '*.svg'),
-  dest: path.resolve(process.env.PWD, config.root.dest, config.tasks.iconFont.dest),
-  sassDest: path.resolve(process.env.PWD, config.root.src, config.tasks.css.src, config.tasks.iconFont.sassDest),
+  src: projectPath(config.root.src, config.tasks.iconFont.src, '*.svg'),
+  dest: projectPath(config.root.dest, config.tasks.iconFont.dest),
+  sassDest: projectPath(config.root.src, config.tasks.css.src, config.tasks.iconFont.sassDest),
   template: path.normalize('./gulpfile.js/tasks/iconFont/template.sass'),
   sassOutputName: '_icons.sass',
   fontPath: url.resolve('.',path.relative(cssPath, fontPath)),

--- a/extras/tasks/server.js
+++ b/extras/tasks/server.js
@@ -1,15 +1,16 @@
-var compress = require('compression')
-var config   = require('../config')
-var express  = require('express')
-var gulp     = require('gulp')
-var log      = require('fancy-log')
-var colors   = require('ansi-colors')
-var logger   = require('morgan')
-var open     = require('open')
-var path     = require('path')
+var compress    = require('compression')
+var config      = require('../config')
+var express     = require('express')
+var gulp        = require('gulp')
+var log         = require('fancy-log')
+var colors      = require('ansi-colors')
+var logger      = require('morgan')
+var open        = require('open')
+var projectPath = require('../lib/projectPath')
+
 
 var settings = {
-  root: path.resolve(process.env.PWD, config.root.dest),
+  root: projectPath(config.root.dest),
   port: process.env.PORT || 5000,
   logLevel: process.env.NODE_ENV ? 'combined' : 'dev',
   staticOptions: {

--- a/gulpfile.js/index.js
+++ b/gulpfile.js/index.js
@@ -7,12 +7,8 @@
   automatically required below.
 */
 
-const path = require('path')
 const gulp = require('gulp')
 const requireDir = require('require-dir')
-
-// Fallback for windows backs out of node_modules folder to root of project
-process.env.PWD = process.env.PWD || path.resolve(process.cwd(), '../../')
 
 // Globally expose config objects
 global.PATH_CONFIG = require('./lib/get-path-config')

--- a/gulpfile.js/lib/get-path-config.js
+++ b/gulpfile.js/lib/get-path-config.js
@@ -1,13 +1,13 @@
-const path = require('path')
+const projectPath = require('./projectPath');
 const fs = require('fs')
 
 function getPathConfig() {
 
   if(process.env.BLENDID_CONFIG_PATH) {
-    return require(path.resolve(process.env.PWD, process.env.BLENDID_CONFIG_PATH, 'path-config.json'))
+    return require(projectPath(process.env.BLENDID_CONFIG_PATH, 'path-config.json'))
   }
 
-  const defaultConfigPath = path.resolve(process.env.PWD, 'config/path-config.json')
+  const defaultConfigPath = projectPath('config/path-config.json')
 
   if (fs.existsSync(defaultConfigPath)) {
     return require(defaultConfigPath)

--- a/gulpfile.js/lib/get-task-config.js
+++ b/gulpfile.js/lib/get-task-config.js
@@ -1,15 +1,15 @@
-const path         = require('path')
 const fs           = require('fs')
+const projectPath  = require('./projectPath')
 const taskDefaults = require('./task-defaults')
 const mergeWith    = require('lodash/mergeWith')
 
 function getTaskConfig () {
 
   if(process.env.BLENDID_CONFIG_PATH) {
-    return require(path.resolve(process.env.PWD, process.env.BLENDID_CONFIG_PATH, 'task-config.js'))
+    return require(projectPath(process.env.BLENDID_CONFIG_PATH, 'task-config.js'))
   }
 
-  const defaultConfigPath = path.resolve(process.env.PWD, 'config/task-config.js')
+  const defaultConfigPath = projectPath('config/task-config.js')
 
   if (fs.existsSync(defaultConfigPath)) {
     return require(defaultConfigPath)

--- a/gulpfile.js/lib/projectPath.js
+++ b/gulpfile.js/lib/projectPath.js
@@ -1,0 +1,19 @@
+var path = require('path')
+
+/**
+ * A function that can be used to resolve a path relatively to the
+ * project directory.
+ *
+ * We often want to resolve paths relatively to the project root
+ * directory. To do that, we use the `INIT_CWD` environment variable
+ * provided by Gulp. This variable always resolves to the project
+ * root directory so we use it as the seed path and then add the
+ * remaining arguments passed and resolving everything using the
+ * `path.resolve` function.
+ *
+ * The returned path is a fully resolved absolute path relative to
+ * the project root directory.
+ */
+module.exports = function projectPath(...paths) {
+  return path.resolve(process.env.INIT_CWD, ...paths);
+}

--- a/gulpfile.js/lib/task-defaults.js
+++ b/gulpfile.js/lib/task-defaults.js
@@ -1,6 +1,7 @@
-const os   = require('os')
-const path = require('path')
-const pkg  = require(path.resolve(process.env.PWD, 'package.json'))
+const os          = require('os')
+const path        = require('path')
+const projectPath = require('./projectPath')
+const pkg         = require(projectPath('package.json'))
 
 module.exports = {
   javascripts: {

--- a/gulpfile.js/lib/webpack-multi-config.js
+++ b/gulpfile.js/lib/webpack-multi-config.js
@@ -6,6 +6,7 @@ if (!TASK_CONFIG.javascripts) {
 
 const path            = require('path')
 const pathToUrl       = require('./pathToUrl')
+const projectPath     = require('./projectPath')
 const webpack         = require('webpack')
 const webpackManifest = require('./webpackManifest')
 const querystring     = require('querystring')
@@ -14,8 +15,8 @@ module.exports = function (env) {
 
   process.env['BABEL_ENV'] = process.env['BABEL_ENV'] || process.env['NODE_ENV'] || env
 
-  const jsSrc = path.resolve(process.env.PWD, PATH_CONFIG.src, PATH_CONFIG.javascripts.src)
-  const jsDest = path.resolve(process.env.PWD, PATH_CONFIG.dest, PATH_CONFIG.javascripts.dest)
+  const jsSrc = projectPath(PATH_CONFIG.src, PATH_CONFIG.javascripts.src)
+  const jsDest = projectPath(PATH_CONFIG.dest, PATH_CONFIG.javascripts.dest)
   const publicPath = pathToUrl(TASK_CONFIG.javascripts.publicPath || PATH_CONFIG.javascripts.dest, '/')
   const rev = TASK_CONFIG.production.rev && env === 'production'
 
@@ -39,7 +40,7 @@ module.exports = function (env) {
     resolve: {
       extensions: extensions,
       alias: TASK_CONFIG.javascripts.alias,
-      modules: [jsSrc, path.resolve(process.env.PWD, 'node_modules')],
+      modules: [jsSrc, projectPath('node_modules')],
     },
     module: {
       rules: [ TASK_CONFIG.javascripts.babelLoader ]

--- a/gulpfile.js/lib/webpackManifest.js
+++ b/gulpfile.js/lib/webpackManifest.js
@@ -1,5 +1,6 @@
-const path = require('path')
-const fs   = require('fs')
+const path        = require('path')
+const projectPath = require('./projectPath')
+const fs          = require('fs')
 
 module.exports = function(jsDest, dest, filename) {
   filename = filename || 'rev-manifest.json'
@@ -18,7 +19,7 @@ module.exports = function(jsDest, dest, filename) {
       }
 
       fs.writeFileSync(
-        path.resolve(process.env.PWD, dest, filename),
+        projectPath(dest, filename),
         JSON.stringify(manifest)
       )
     })

--- a/gulpfile.js/tasks/browserSync.js
+++ b/gulpfile.js/tasks/browserSync.js
@@ -1,11 +1,11 @@
 if(global.production) return
 
-var browserSync       = require('browser-sync')
-var gulp              = require('gulp')
-var webpack           = require('webpack')
+var browserSync        = require('browser-sync')
+var gulp               = require('gulp')
+var webpack            = require('webpack')
 var webpackMultiConfig = require('../lib/webpack-multi-config')
-var pathToUrl         = require('../lib/pathToUrl')
-var path              = require('path')
+var pathToUrl          = require('../lib/pathToUrl')
+var projectPath        = require('../lib/projectPath')
 
 var browserSyncTask = function() {
 
@@ -19,15 +19,15 @@ var browserSyncTask = function() {
     }
   }
 
-  // Resolve path from PWD
+  // Resolve path from project
   if(TASK_CONFIG.browserSync.server && TASK_CONFIG.browserSync.server.baseDir) {
-    TASK_CONFIG.browserSync.server.baseDir = path.resolve(process.env.PWD, TASK_CONFIG.browserSync.server.baseDir)
+    TASK_CONFIG.browserSync.server.baseDir = projectPath(TASK_CONFIG.browserSync.server.baseDir)
   }
 
-  // Resolve files from PWD
+  // Resolve files from project
   if(TASK_CONFIG.browserSync.files) {
     TASK_CONFIG.browserSync.files = TASK_CONFIG.browserSync.files.map(function(glob) {
-      return path.resolve(process.env.PWD, glob)
+      return projectPath(glob)
     })
   }
 

--- a/gulpfile.js/tasks/clean.js
+++ b/gulpfile.js/tasks/clean.js
@@ -1,11 +1,11 @@
-const gulp = require('gulp')
-const del  = require('del')
-const path = require('path')
+const gulp        = require('gulp')
+const del         = require('del')
+const projectPath = require('../lib/projectPath')
 
 const cleanTask = function (cb) {
   var patterns = TASK_CONFIG.clean && TASK_CONFIG.clean.patterns ?
     TASK_CONFIG.clean.patterns :
-    path.resolve(process.env.PWD, PATH_CONFIG.dest)
+    projectPath(PATH_CONFIG.dest)
 
   return del(patterns, { force: true })
 }

--- a/gulpfile.js/tasks/fonts.js
+++ b/gulpfile.js/tasks/fonts.js
@@ -3,13 +3,14 @@ if(!TASK_CONFIG.fonts) return
 var browserSync = require('browser-sync')
 var changed     = require('gulp-changed')
 var gulp        = require('gulp')
-var path        = require('path')
+var projectPath = require('../lib/projectPath')
+
 
 var fontsTask = function() {
 
   var paths = {
-    src: path.resolve(process.env.PWD, PATH_CONFIG.src, PATH_CONFIG.fonts.src, '**/*.{' + TASK_CONFIG.fonts.extensions + '}'),
-    dest: path.resolve(process.env.PWD, PATH_CONFIG.dest, PATH_CONFIG.fonts.dest)
+    src: projectPath(PATH_CONFIG.src, PATH_CONFIG.fonts.src, '**/*.{' + TASK_CONFIG.fonts.extensions + '}'),
+    dest: projectPath(PATH_CONFIG.dest, PATH_CONFIG.fonts.dest)
   }
 
   return gulp.src([paths.src, '*!README.md'])

--- a/gulpfile.js/tasks/gh-pages.js
+++ b/gulpfile.js/tasks/gh-pages.js
@@ -1,13 +1,13 @@
-const ghPages = require('gulp-gh-pages')
-const gulp    = require('gulp')
-const os      = require('os')
-const path    = require('path')
+const ghPages     = require('gulp-gh-pages')
+const gulp        = require('gulp')
+const os          = require('os')
+const projectPath = require('../lib/projectPath')
 
 const ghPagesTask = function() {
-  const pkg = require(path.resolve(process.env.PWD, 'package.json'))
+  const pkg = require(projectPath('package.json'))
 
   const settings = {
-    src: path.resolve(process.env.PWD, PATH_CONFIG.finalDest, '**/*')
+    src: projectPath(PATH_CONFIG.finalDest, '**/*')
   }
 
   return gulp.src(settings.src)

--- a/gulpfile.js/tasks/html.js
+++ b/gulpfile.js/tasks/html.js
@@ -5,26 +5,26 @@ const data           = require('gulp-data')
 const gulp           = require('gulp')
 const gulpif         = require('gulp-if')
 const handleErrors   = require('../lib/handleErrors')
+const projectPath    = require('../lib/projectPath')
 const htmlmin        = require('gulp-htmlmin')
-const path           = require('path')
 const nunjucksRender = require('gulp-nunjucks-render')
 const fs             = require('fs')
 
 const htmlTask = function() {
 
-  const exclude = '!' + path.resolve(process.env.PWD, PATH_CONFIG.src, PATH_CONFIG.html.src, '**/{' + TASK_CONFIG.html.excludeFolders.join(',') + '}/**')
+  const exclude = '!' + projectPath(PATH_CONFIG.src, PATH_CONFIG.html.src, '**/{' + TASK_CONFIG.html.excludeFolders.join(',') + '}/**')
 
   const paths = {
-    src: [path.resolve(process.env.PWD, PATH_CONFIG.src, PATH_CONFIG.html.src, '**/*.{' + TASK_CONFIG.html.extensions + '}'), exclude],
-    dest: path.resolve(process.env.PWD, PATH_CONFIG.dest, PATH_CONFIG.html.dest),
+    src: [projectPath(PATH_CONFIG.src, PATH_CONFIG.html.src, '**/*.{' + TASK_CONFIG.html.extensions + '}'), exclude],
+    dest: projectPath(PATH_CONFIG.dest, PATH_CONFIG.html.dest),
   }
 
   const dataFunction = TASK_CONFIG.html.dataFunction || function(file) {
-    const dataPath = path.resolve(process.env.PWD, PATH_CONFIG.src, PATH_CONFIG.html.src, TASK_CONFIG.html.dataFile)
+    const dataPath = projectPath(PATH_CONFIG.src, PATH_CONFIG.html.src, TASK_CONFIG.html.dataFile)
     return JSON.parse(fs.readFileSync(dataPath, 'utf8'))
   }
 
-  const nunjucksRenderPath = [ path.resolve(process.env.PWD, PATH_CONFIG.src, PATH_CONFIG.html.src) ]
+  const nunjucksRenderPath = [ projectPath(PATH_CONFIG.src, PATH_CONFIG.html.src) ]
   TASK_CONFIG.html.nunjucksRender.path = TASK_CONFIG.html.nunjucksRender.path || nunjucksRenderPath
 
   return gulp.src(paths.src)

--- a/gulpfile.js/tasks/http2-upgrade.js
+++ b/gulpfile.js/tasks/http2-upgrade.js
@@ -10,10 +10,10 @@ gulp.task('http2-upgrade', function() {
   del([projectPath(PATH_CONFIG.src, PATH_CONFIG.stylesheets.src)], { force: true })
   log(colors.green('Cleaned stylesheets directory'))
 
-  const configStream = gulp.src('../extras/http2/**/*')
+  const configStream = gulp.src('extras/http2/**/*')
     .pipe(gulp.dest(projectPath()))
 
-  const srcStream = gulp.src(['../src/stylesheets', '../src/javascripts', '../src/html'])
+  const srcStream = gulp.src(['src/stylesheets', 'src/javascripts', 'src/html'])
    .pipe(gulp.dest(projectPath(PATH_CONFIG.src)))
 
   log(colors.green('Created HTTP/2 ready stylesheets directory'))

--- a/gulpfile.js/tasks/http2-upgrade.js
+++ b/gulpfile.js/tasks/http2-upgrade.js
@@ -2,18 +2,19 @@ const gulp = require('gulp')
 const log = require('fancy-log')
 const colors = require('ansi-colors')
 const mergeStream = require('merge-stream')
-const path = require('path')
-const del  = require('del')
+const del = require('del')
+const projectPath = require('../lib/projectPath')
+
 
 gulp.task('http2-upgrade', function() {
-  del([path.resolve(process.env.PWD, PATH_CONFIG.src, PATH_CONFIG.stylesheets.src)], { force: true })
+  del([projectPath(PATH_CONFIG.src, PATH_CONFIG.stylesheets.src)], { force: true })
   log(colors.green('Cleaned stylesheets directory'))
 
   const configStream = gulp.src('../extras/http2/**/*')
-    .pipe(gulp.dest(process.env.PWD))
+    .pipe(gulp.dest(projectPath()))
 
   const srcStream = gulp.src(['../src/stylesheets', '../src/javascripts', '../src/html'])
-   .pipe(gulp.dest(path.join(process.env.PWD, PATH_CONFIG.src)))
+   .pipe(gulp.dest(projectPath(PATH_CONFIG.src)))
 
   log(colors.green('Created HTTP/2 ready stylesheets directory'))
   log(colors.green('Added some HTTP/2 helpers to the html directory'))

--- a/gulpfile.js/tasks/images.js
+++ b/gulpfile.js/tasks/images.js
@@ -3,13 +3,13 @@ if(!TASK_CONFIG.images) return
 var browserSync = require('browser-sync')
 var changed     = require('gulp-changed')
 var gulp        = require('gulp')
-var path        = require('path')
+var projectPath = require('../lib/projectPath')
 
 var imagesTask = function() {
 
   var paths = {
-    src: path.resolve(process.env.PWD, PATH_CONFIG.src, PATH_CONFIG.images.src, '**/*.{' + TASK_CONFIG.images.extensions + '}'),
-    dest: path.resolve(process.env.PWD, PATH_CONFIG.dest, PATH_CONFIG.images.dest)
+    src: projectPath(PATH_CONFIG.src, PATH_CONFIG.images.src, '**/*.{' + TASK_CONFIG.images.extensions + '}'),
+    dest: projectPath(PATH_CONFIG.dest, PATH_CONFIG.images.dest)
   }
 
   return gulp.src([paths.src, , '*!README.md'])

--- a/gulpfile.js/tasks/init-config.js
+++ b/gulpfile.js/tasks/init-config.js
@@ -1,12 +1,12 @@
 var gulp = require('gulp')
 var log = require('fancy-log')
 var colors = require('ansi-colors')
-var path = require('path')
+var projectPath = require('../lib/projectPath')
 var merge = require('merge-stream')
 
 gulp.task('init-config', function() {
   var configStream = gulp.src(['./path-config.json', './task-config.js'])
-    .pipe(gulp.dest(path.join(process.env.PWD, 'config')))
+    .pipe(gulp.dest(projectPath('config')))
 
   log(colors.green('Adding default path-config.json and task-config.js files to ./config/'))
 

--- a/gulpfile.js/tasks/init-config.js
+++ b/gulpfile.js/tasks/init-config.js
@@ -4,8 +4,8 @@ var colors = require('ansi-colors')
 var projectPath = require('../lib/projectPath')
 var merge = require('merge-stream')
 
-gulp.task('init-config', function() {
-  var configStream = gulp.src(['./path-config.json', './task-config.js'])
+gulp.task('init-config', function () {
+  var configStream = gulp.src(['gulpfile.js/path-config.json', 'gulpfile.js/task-config.js'])
     .pipe(gulp.dest(projectPath('config')))
 
   log(colors.green('Adding default path-config.json and task-config.js files to ./config/'))

--- a/gulpfile.js/tasks/init-craft.js
+++ b/gulpfile.js/tasks/init-craft.js
@@ -5,10 +5,10 @@ const mergeStream = require('merge-stream')
 const projectPath = require('../lib/projectPath')
 
 gulp.task('init-craft', function() {
-  const configStream = gulp.src(['../extras/craft/**/*', '*!ASSET-README.md'])
+  const configStream = gulp.src(['extras/craft/**/*', '!**/ASSETS-README.md'])
     .pipe(gulp.dest(projectPath()))
 
-  const srcStream = gulp.src(['../src/**/*', '*.gitkeep', '!../src/html{,/**}', '!../src/static{,/**}'])
+  const srcStream = gulp.src(['src/**/*', 'src/**/.gitkeep', '!src/html{,/**}', '!src/static{,/**}'])
     .pipe(gulp.dest(projectPath(PATH_CONFIG.src)))
 
 

--- a/gulpfile.js/tasks/init-craft.js
+++ b/gulpfile.js/tasks/init-craft.js
@@ -2,14 +2,14 @@ const gulp = require('gulp')
 const log = require('fancy-log')
 const colors = require('ansi-colors')
 const mergeStream = require('merge-stream')
-const path = require('path')
+const projectPath = require('../lib/projectPath')
 
 gulp.task('init-craft', function() {
   const configStream = gulp.src(['../extras/craft/**/*', '*!ASSET-README.md'])
-    .pipe(gulp.dest(process.env.PWD))
+    .pipe(gulp.dest(projectPath()))
 
   const srcStream = gulp.src(['../src/**/*', '*.gitkeep', '!../src/html{,/**}', '!../src/static{,/**}'])
-    .pipe(gulp.dest(path.join(process.env.PWD, PATH_CONFIG.src)))
+    .pipe(gulp.dest(projectPath(PATH_CONFIG.src)))
 
 
   log(colors.green('Added gulpRev plugin to craft/plugins/gulprev!'))

--- a/gulpfile.js/tasks/init-drupal.js
+++ b/gulpfile.js/tasks/init-drupal.js
@@ -10,14 +10,14 @@ const projectPath = require('../lib/projectPath')
 gulp.task('init-drupal', function() {
   const envBasename = path.basename(process.env.INIT_CWD)
 
-  const configStream = gulp.src(['../extras/drupal/**/*', '!../extras/drupal/src/', '!../extras/drupal/src/**/*', '!**/README.md'])
+  const configStream = gulp.src(['extras/drupal/**/*', '!extras/drupal/src/', '!extras/drupal/src/**/*', '!**/README.md'])
     .pipe(rename(function (filepath) {
       filepath.basename = filepath.basename.replace('THEMENAME', envBasename);
     }))
     .pipe(replace('THEMENAME', envBasename))
     .pipe(gulp.dest(projectPath()))
 
-  const srcStream = gulp.src(['../extras/drupal/src/**/*', '*.gitkeep'])
+  const srcStream = gulp.src(['extras/drupal/src/**/*', 'extras/drupal/src/**/.gitkeep'])
     .pipe(gulp.dest(projectPath(PATH_CONFIG.src)))
 
   log(colors.green('Created config/path-config.json'))

--- a/gulpfile.js/tasks/init-drupal.js
+++ b/gulpfile.js/tasks/init-drupal.js
@@ -5,19 +5,20 @@ const rename = require('gulp-rename')
 const replace = require('gulp-replace')
 const mergeStream = require('merge-stream')
 const path = require('path')
+const projectPath = require('../lib/projectPath')
 
 gulp.task('init-drupal', function() {
-  const envBasename = path.basename(process.env.PWD)
+  const envBasename = path.basename(process.env.INIT_CWD)
 
   const configStream = gulp.src(['../extras/drupal/**/*', '!../extras/drupal/src/', '!../extras/drupal/src/**/*', '!**/README.md'])
     .pipe(rename(function (filepath) {
       filepath.basename = filepath.basename.replace('THEMENAME', envBasename);
     }))
     .pipe(replace('THEMENAME', envBasename))
-    .pipe(gulp.dest(process.env.PWD))
+    .pipe(gulp.dest(projectPath()))
 
   const srcStream = gulp.src(['../extras/drupal/src/**/*', '*.gitkeep'])
-    .pipe(gulp.dest(path.join(process.env.PWD, PATH_CONFIG.src)))
+    .pipe(gulp.dest(projectPath(PATH_CONFIG.src)))
 
   log(colors.green('Created config/path-config.json'))
   log(colors.green('Created config/task-config.js'))

--- a/gulpfile.js/tasks/init-rails.js
+++ b/gulpfile.js/tasks/init-rails.js
@@ -4,7 +4,7 @@ var colors = require('ansi-colors')
 var projectPath = require('../lib/projectPath')
 
 gulp.task('init-rails', function() {
-  var stream = gulp.src(['../extras/rails/**/*', '*!README.md'])
+  var stream = gulp.src(['extras/rails/**/*', 'extras/rails/**/.gitkeep', '!**/ASSETS-README.md'])
     .pipe(gulp.dest(projectPath()))
 
   log(colors.green('Created app/helpers/blendid_asset_helper.rb'))

--- a/gulpfile.js/tasks/init-rails.js
+++ b/gulpfile.js/tasks/init-rails.js
@@ -1,10 +1,11 @@
 var gulp = require('gulp')
 var log = require('fancy-log')
 var colors = require('ansi-colors')
+var projectPath = require('../lib/projectPath')
 
 gulp.task('init-rails', function() {
   var stream = gulp.src(['../extras/rails/**/*', '*!README.md'])
-    .pipe(gulp.dest(process.env.PWD))
+    .pipe(gulp.dest(projectPath()))
 
   log(colors.green('Created app/helpers/blendid_asset_helper.rb'))
   log(colors.green('Created config/initializers/blendid.rb'))

--- a/gulpfile.js/tasks/init.js
+++ b/gulpfile.js/tasks/init.js
@@ -1,18 +1,18 @@
 var gulp = require('gulp')
 var log = require('fancy-log')
 var colors = require('ansi-colors')
-var path = require('path')
+var projectPath = require('../lib/projectPath')
 var merge = require('merge-stream')
 
 gulp.task('init', function() {
   var defaultStream = gulp.src(['../extras/default/**/*'])
-    .pipe(gulp.dest(process.env.PWD))
+    .pipe(gulp.dest(projectPath()))
 
   var configStream = gulp.src(['./path-config.json', './task-config.js'])
-    .pipe(gulp.dest(path.join(process.env.PWD, 'config')))
+    .pipe(gulp.dest(projectPath('config')))
 
   var srcStream = gulp.src(['../src/**/*', '*.gitkeep'])
-    .pipe(gulp.dest(path.join(process.env.PWD, PATH_CONFIG.src)))
+    .pipe(gulp.dest(projectPath(PATH_CONFIG.src)))
 
   log(colors.green('Generating default Blendid project files'))
   log(colors.yellow(`

--- a/gulpfile.js/tasks/init.js
+++ b/gulpfile.js/tasks/init.js
@@ -5,13 +5,13 @@ var projectPath = require('../lib/projectPath')
 var merge = require('merge-stream')
 
 gulp.task('init', function() {
-  var defaultStream = gulp.src(['../extras/default/**/*'])
+  var defaultStream = gulp.src(['extras/default/**/*', 'extras/default/**/.*'])
     .pipe(gulp.dest(projectPath()))
 
-  var configStream = gulp.src(['./path-config.json', './task-config.js'])
+  var configStream = gulp.src(['gulpfile.js/path-config.json', 'gulpfile.js/task-config.js'])
     .pipe(gulp.dest(projectPath('config')))
 
-  var srcStream = gulp.src(['../src/**/*', '*.gitkeep'])
+  var srcStream = gulp.src(['src/**/*', 'src/**/.gitkeep'])
     .pipe(gulp.dest(projectPath(PATH_CONFIG.src)))
 
   log(colors.green('Generating default Blendid project files'))

--- a/gulpfile.js/tasks/production.js
+++ b/gulpfile.js/tasks/production.js
@@ -3,8 +3,9 @@ const gulpSequence    = require('gulp-sequence')
 const getEnabledTasks = require('../lib/getEnabledTasks')
 const os              = require('os')
 const fs              = require('fs')
-var del               = require('del')
+const del             = require('del')
 const path            = require('path')
+const projectPath     = require('../lib/projectPath')
 
 const productionTask = function(cb) {
   global.production = true
@@ -12,7 +13,7 @@ const productionTask = function(cb) {
   // Build to a temporary directory, then move compiled files as a last step
   PATH_CONFIG.finalDest = PATH_CONFIG.dest
   PATH_CONFIG.dest = PATH_CONFIG.temp
-      ? path.join(process.env.PWD, PATH_CONFIG.temp)
+      ? projectPath(PATH_CONFIG.temp)
       : path.join(os.tmpdir(), 'gulp-starter')
 
   // Make sure the temp directory exists and is empty

--- a/gulpfile.js/tasks/replace-files.js
+++ b/gulpfile.js/tasks/replace-files.js
@@ -1,11 +1,11 @@
-var gulp = require('gulp')
-var fs   = require('fs-extra')
-var del  = require('del')
-var path = require('path')
+var gulp        = require('gulp')
+var fs          = require('fs-extra')
+var del         = require('del')
+var projectPath = require('../lib/projectPath')
 
 var replaceFiles = function (cb) {
-  var temp = path.resolve(process.env.PWD, PATH_CONFIG.dest)
-  var dest = path.resolve(process.env.PWD, PATH_CONFIG.finalDest)
+  var temp = projectPath(PATH_CONFIG.dest)
+  var dest = projectPath(PATH_CONFIG.finalDest)
   var delPatterns = (TASK_CONFIG.clean && TASK_CONFIG.clean.patterns) ? TASK_CONFIG.clean.patterns : dest
 
   del.sync(delPatterns, { force: true })

--- a/gulpfile.js/tasks/rev/rev-assets.js
+++ b/gulpfile.js/tasks/rev/rev-assets.js
@@ -1,17 +1,17 @@
-var gulp      = require('gulp')
-var path      = require('path')
-var rev       = require('gulp-rev')
-var revNapkin = require('gulp-rev-napkin');
+var gulp        = require('gulp')
+var rev         = require('gulp-rev')
+var revNapkin   = require('gulp-rev-napkin');
+var projectPath = require('../../lib/projectPath')
 
 // 1) Add md5 hashes to assets referenced by CSS and JS files
 gulp.task('rev-assets', function() {
   // Ignore files that may reference assets. We'll rev them next.
-  var ignoreThese = '!' + path.resolve(process.env.PWD, PATH_CONFIG.dest,'**/*+(css|js|map|json|html)')
+  var ignoreThese = '!' + projectPath(PATH_CONFIG.dest,'**/*+(css|js|map|json|html)')
 
-  return gulp.src([path.resolve(process.env.PWD, PATH_CONFIG.dest,'**/*'), ignoreThese])
+  return gulp.src([projectPath(PATH_CONFIG.dest,'**/*'), ignoreThese])
     .pipe(rev())
     .pipe(gulp.dest(PATH_CONFIG.dest))
     .pipe(revNapkin({ verbose: false, force: true }))
-    .pipe(rev.manifest(path.resolve(process.env.PWD, PATH_CONFIG.dest, 'rev-manifest.json'), {merge: true}))
+    .pipe(rev.manifest(projectPath(PATH_CONFIG.dest, 'rev-manifest.json'), {merge: true}))
     .pipe(gulp.dest(''))
 })

--- a/gulpfile.js/tasks/rev/rev-css.js
+++ b/gulpfile.js/tasks/rev/rev-css.js
@@ -1,15 +1,15 @@
-var gulp      = require('gulp')
-var path      = require('path')
-var rev       = require('gulp-rev')
-var revNapkin = require('gulp-rev-napkin')
+var gulp        = require('gulp')
+var rev         = require('gulp-rev')
+var revNapkin   = require('gulp-rev-napkin')
+var projectPath = require('../../lib/projectPath')
 
 // 3) Rev and compress CSS and JS files (this is done after assets, so that if a
 //    referenced asset hash changes, the parent hash will change as well
 gulp.task('rev-css', function(){
-  return gulp.src(path.resolve(process.env.PWD, PATH_CONFIG.dest,'**/*.css'))
+  return gulp.src(projectPath(PATH_CONFIG.dest,'**/*.css'))
     .pipe(rev())
     .pipe(gulp.dest(PATH_CONFIG.dest))
     .pipe(revNapkin({verbose: false, force: true}))
-    .pipe(rev.manifest(path.resolve(process.env.PWD, PATH_CONFIG.dest, 'rev-manifest.json'), {merge: true}))
+    .pipe(rev.manifest(projectPath(PATH_CONFIG.dest, 'rev-manifest.json'), {merge: true}))
     .pipe(gulp.dest(''))
 })

--- a/gulpfile.js/tasks/rev/rev-update-references.js
+++ b/gulpfile.js/tasks/rev/rev-update-references.js
@@ -1,12 +1,12 @@
-var gulp       = require('gulp')
-var path       = require('path')
-var revReplace = require('gulp-rev-replace')
+var gulp        = require('gulp')
+var revReplace  = require('gulp-rev-replace')
+var projectPath = require('../../lib/projectPath')
 
 // 2) Update asset references with reved filenames in compiled css + js
 gulp.task('rev-update-references', function(){
-  var manifest = gulp.src(path.resolve(process.env.PWD, PATH_CONFIG.dest, "rev-manifest.json"))
+  var manifest = gulp.src(projectPath(PATH_CONFIG.dest, "rev-manifest.json"))
 
-  return gulp.src(path.resolve(process.env.PWD, PATH_CONFIG.dest,'**/**.{css,js}'))
+  return gulp.src(projectPath(PATH_CONFIG.dest,'**/**.{css,js}'))
     .pipe(revReplace({manifest: manifest}))
     .pipe(gulp.dest(PATH_CONFIG.dest))
 })

--- a/gulpfile.js/tasks/rev/update-html.js
+++ b/gulpfile.js/tasks/rev/update-html.js
@@ -1,13 +1,13 @@
 if(!TASK_CONFIG.html) return false
 
-var gulp       = require('gulp')
-var revReplace = require('gulp-rev-replace')
-var path       = require('path')
+var gulp        = require('gulp')
+var revReplace  = require('gulp-rev-replace')
+var projectPath = require('../../lib/projectPath')
 
 // 4) Update asset references in HTML
 gulp.task('update-html', function(){
-  var manifest = gulp.src(path.resolve(process.env.PWD, PATH_CONFIG.dest, "rev-manifest.json"))
-  return gulp.src(path.resolve(process.env.PWD, PATH_CONFIG.dest, PATH_CONFIG.html.dest, '**/*.html'))
+  var manifest = gulp.src(projectPath(PATH_CONFIG.dest, "rev-manifest.json"))
+  return gulp.src(projectPath(PATH_CONFIG.dest, PATH_CONFIG.html.dest, '**/*.html'))
     .pipe(revReplace({ manifest: manifest }))
-    .pipe(gulp.dest(path.resolve(process.env.PWD, PATH_CONFIG.dest, PATH_CONFIG.html.dest)))
+    .pipe(gulp.dest(projectPath(PATH_CONFIG.dest, PATH_CONFIG.html.dest)))
 })

--- a/gulpfile.js/tasks/sizereport.js
+++ b/gulpfile.js/tasks/sizereport.js
@@ -1,9 +1,9 @@
 var gulp         = require('gulp')
 var sizereport   = require('gulp-sizereport')
-var path         = require('path')
+var projectPath  = require('../lib/projectPath')
 
 gulp.task('size-report', function() {
-  return gulp.src([path.resolve(process.env.PWD, PATH_CONFIG.dest, '**/*'), '*!rev-manifest.json'])
+  return gulp.src([projectPath(PATH_CONFIG.dest, '**/*'), '*!rev-manifest.json'])
     .pipe(sizereport({
       gzip: true
     }))

--- a/gulpfile.js/tasks/static.js
+++ b/gulpfile.js/tasks/static.js
@@ -1,20 +1,21 @@
 if(!TASK_CONFIG.static) return
 
-const changed = require('gulp-changed')
-const gulp    = require('gulp')
-const path    = require('path')
+const changed     = require('gulp-changed')
+const gulp        = require('gulp')
+const path        = require('path')
+const projectPath = require('../lib/projectPath')
 
 const staticTask = function() {
-  const srcPath = path.resolve(process.env.PWD, PATH_CONFIG.src, PATH_CONFIG.static.src)
+  const srcPath = projectPath(PATH_CONFIG.src, PATH_CONFIG.static.src)
   const defaultSrcOptions = { dot: true }
   const options = Object.assign(defaultSrcOptions, (TASK_CONFIG.static.srcOptions || {}))
 
   const paths = {
     src: [
       path.join(srcPath, '**/*'),
-      path.resolve(process.env.PWD, '!' + PATH_CONFIG.src, PATH_CONFIG.static.src, 'README.md')
+      projectPath('!' + PATH_CONFIG.src, PATH_CONFIG.static.src, 'README.md')
     ],
-    dest: path.resolve(process.env.PWD, PATH_CONFIG.dest, PATH_CONFIG.static.dest)
+    dest: projectPath(PATH_CONFIG.dest, PATH_CONFIG.static.dest)
   }
 
   return gulp.src(paths.src, options)

--- a/gulpfile.js/tasks/stylesheets.js
+++ b/gulpfile.js/tasks/stylesheets.js
@@ -7,19 +7,19 @@ var sass         = require('gulp-sass')
 var sourcemaps   = require('gulp-sourcemaps')
 var handleErrors = require('../lib/handleErrors')
 var autoprefixer = require('gulp-autoprefixer')
-var path         = require('path')
+var projectPath  = require('../lib/projectPath')
 var cssnano      = require('gulp-cssnano')
 
 var sassTask = function () {
 
   var paths = {
-    src: path.resolve(process.env.PWD, PATH_CONFIG.src, PATH_CONFIG.stylesheets.src, '**/*.{' + TASK_CONFIG.stylesheets.extensions + '}'),
-    dest: path.resolve(process.env.PWD, PATH_CONFIG.dest, PATH_CONFIG.stylesheets.dest)
+    src: projectPath(PATH_CONFIG.src, PATH_CONFIG.stylesheets.src, '**/*.{' + TASK_CONFIG.stylesheets.extensions + '}'),
+    dest: projectPath(PATH_CONFIG.dest, PATH_CONFIG.stylesheets.dest)
   }
 
   if(TASK_CONFIG.stylesheets.sass && TASK_CONFIG.stylesheets.sass.includePaths) {
     TASK_CONFIG.stylesheets.sass.includePaths = TASK_CONFIG.stylesheets.sass.includePaths.map(function(includePath) {
-      return path.resolve(process.env.PWD, includePath)
+      return projectPath(includePath)
     })
   }
 

--- a/gulpfile.js/tasks/svgSprite.js
+++ b/gulpfile.js/tasks/svgSprite.js
@@ -3,13 +3,13 @@ if(!TASK_CONFIG.svgSprite) return
 const browserSync = require('browser-sync')
 const gulp        = require('gulp')
 const svgstore    = require('gulp-svgstore')
-const path        = require('path')
+const projectPath = require('../lib/projectPath')
 
 const svgSpriteTask = function() {
 
   const settings = {
-    src: path.resolve(process.env.PWD, PATH_CONFIG.src, PATH_CONFIG.icons.src, '*.svg'),
-    dest: path.resolve(process.env.PWD, PATH_CONFIG.dest, PATH_CONFIG.icons.dest)
+    src: projectPath(PATH_CONFIG.src, PATH_CONFIG.icons.src, '*.svg'),
+    dest: projectPath(PATH_CONFIG.dest, PATH_CONFIG.icons.dest)
   }
 
   return gulp.src(settings.src)

--- a/gulpfile.js/tasks/watch.js
+++ b/gulpfile.js/tasks/watch.js
@@ -1,6 +1,7 @@
-var gulp   = require('gulp')
-var path   = require('path')
-var watch  = require('gulp-watch')
+var gulp        = require('gulp')
+var watch       = require('gulp-watch')
+var path        = require('path')
+var projectPath = require('../lib/projectPath')
 
 var watchTask = function() {
   var watchableTasks = ['fonts', 'iconFont', 'images', 'svgSprite', 'html', 'stylesheets', 'static']
@@ -29,7 +30,7 @@ var watchTask = function() {
     }
 
     if(taskConfig) {
-      var srcPath = path.resolve(process.env.PWD, PATH_CONFIG.src, taskPath.src)
+      var srcPath = projectPath(PATH_CONFIG.src, taskPath.src)
       var globPattern = '**/*' + (taskConfig.extensions ? '.{' + taskConfig.extensions.join(',') + '}' : '')
       watch(path.join(srcPath, globPattern), watchConfig, function() {
        require('./' + taskName)()


### PR DESCRIPTION
commit 73b30596ec9961320befc5325846d8cb6bc4ee1c

Fixed process.cwd() changes and reverted previous fixes

Changing from `--gulpfile node_modules/blendid/gulpfile.js` to `--gulpfile node_modules/blendid/gulpfile.js/index.js` had the unintended consequence of making the `process.cwd()` not the same being one directory lower than before.

As such, a workaround fix was performed in 19e4825 & 538c85c to make blendid assets now relative one level lower also.

This was not a proper fix and instead, the `bin/blendid` script has been updated to use one level lower by pointing to the previous directory directly instead of pointing to the main file of the directory. Previous modifications of previous workaround were reverted.

As part of testing, fixed a bunch of small globbing problem with Gulp like .gitkeep files not copied or some other files not ignored correctly.

commit 262796320d40cf60b45235655c4d2f6ccf33e126

Fix resolution of calling project `package.json` file (Fixes #532)

It appears that `process.env.PWD` is not consistent across platform as well as across sub-directory invocations. Indeed, even if it is consistent on Mac OS X (and probably Unix at the same time but untested), there is inconsitencies problem on Windows when using a POSIX transformer platform like Cygwin or MSYS2.

Indeed, in those cases, `PWD` is not the canonical Windows path but the original POSIX path of the terminal. Furthermore, invoking from a sub-directory also fiddles with the `PWD` adding subdirectory into it.

To fix that, it seems that Gulp is providing an environment variable that points to the root directory of the project and which is constant across platforms. See https://github.com/gulpjs/gulp/commit/2bf23ba407a594ac8ee7e693ec93b17dd906f926 for the actual INIT_CWD implementation.

So, to fix the problem everywhere, added a function `resolveRelativeToProject` that does the correct resolving using `INIT_CWD` environment variable instead of the previously used `PWD`.

To make stuff easier to use next time, a `projectPath` function was added that does the resolving of paths relative to the project root directory. All previous usages of `path.(resolve|join (process.env.PWD, ...)` that were used throughout the website are now using `projectPath(...)` instead.

Fixed bin script `blendid/gulpfile.js/index.js` resolution to use `__dirname` instead of `require.resolve`. The `require.resolve` does not work when using `yarn link` to development `blendid` features. Indeed, `require.resolve` does the resolution from the linked project leading to `blendid` not being resolvable (because not present in the linked `node_modules` directory). By using `__dirname`, we achieve the same goal as before but being more robust to linked project for development.