### PR TITLE
Added fs-extra as a direct dependency of Blendid

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "del": "2.2.2",
     "es6-promise": "^4.1.1",
     "fancy-log": "^1.3.2",
+    "fs-extra": "^3.0.1",
     "gulp": "3.9.1",
     "gulp-autoprefixer": "3.1.1",
     "gulp-changed": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2351,7 +2351,7 @@ fs-exists-sync@^0.1.0:
   version "0.1.0"
   resolved "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz#982d6893af918e72d08dec9e8673ff2b5a8d6add"
 
-fs-extra@3.0.1:
+fs-extra@3.0.1, fs-extra@^3.0.1:
   version "3.0.1"
   resolved "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz#3794f378c58b342ea7dbbb23095109c4b3b62291"
   dependencies:


### PR DESCRIPTION
The fs-extra is required directly by Blendid in file `gulpfile.js/tasks/replace-files.js`. However, this dependency was expected to be present transitively via `browser-sync`.

Since it's a direct dependency of Blendid, it should be listed as such in the `package.json`. By not being present, it was causing us problem when using Yarn workspaces where `fs-extra` was not resolvable correctly (because it was in different `node_modules` folder).

Used version `fs-extra@3.0.1` to remain the same as `browser-sync#fs-extra`.