### PR TITLE
fix(ci testing): use new way to run xvfb on Travis CI...

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,9 @@ node_js:
   - "6.11.1"
   - "7.2.0"
   - "8.0.0"
-before_script:
-  # http://docs.travis-ci.com/user/gui-and-headless-browsers/#Using-xvfb-to-Run-Tests-That-Require-GUI-(e.g.-a-Web-browser)
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
+dist: xenial
+services:
+  - xvfb
 script:
   - yarn run dev:test
   - yarn run build


### PR DESCRIPTION
In April 2019, Travis changed its default build environment to Xenial. Config changes are needed to keep Travis working

Another branch that branches off the same point (the current tip of master) failed with

> The command "sh -e /etc/init.d/xvfb start" failed and exited

https://travis-ci.org/vigetlabs/blendid/builds/550025529. Researching that error immediately turns up the fix applied in this PR. This PR's branch passes https://travis-ci.org/vigetlabs/blendid/builds/550292758

References:
* https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment#3-headless-browser-testing
* https://docs.travis-ci.com/user/gui-and-headless-browsers/#using-xvfb-to-run-tests-that-require-a-gui